### PR TITLE
Fix stale context errors when pruning at the end of a run

### DIFF
--- a/.agents/plans/014-fix-stale-context-flush.md
+++ b/.agents/plans/014-fix-stale-context-flush.md
@@ -1,0 +1,47 @@
+---
+name: 014-fix-stale-context-flush
+description: Fix stale extension context errors when pending prune batches flush near the end of an agent run.
+steps:
+  - phase: discovery
+    steps:
+      - "- [x] step 1: reproduce stale context errors in live Pi print-mode runs"
+      - "- [x] step 2: inspect flushPending callers and Pi session persistence boundaries"
+      - "- [x] step 3: identify which prune modes need runtime delivery versus session delivery"
+  - phase: implementation
+    steps:
+      - "- [x] step 1: make flushPending return structured success and failure results"
+      - "- [x] step 2: guard concurrent flushes and restore pending batches on retry-safe failures"
+      - "- [x] step 3: use runtime delivery for active tool-loop flushes"
+      - "- [x] step 4: use captured session persistence for final-message flushes"
+      - "- [x] step 5: avoid queuing context_prune housekeeping results"
+      - "- [x] step 6: preserve captured tool arguments from input, args, or arguments fields"
+  - phase: validation
+    steps:
+      - "- [x] step 1: run TypeScript and diff hygiene checks"
+      - "- [x] step 2: verify agentic-auto pruning in live Pi"
+      - "- [x] step 3: verify agent-message pruning in live Pi"
+      - "- [x] step 4: verify every-turn pruning in live Pi"
+      - "- [x] step 5: verify context_tree_query recovers pruned output"
+---
+
+# 014-fix-stale-context-flush
+
+## Phase 1 — Discovery
+- [x] step 1: reproduce stale context errors in live Pi print-mode runs
+- [x] step 2: inspect `flushPending` callers and Pi session persistence boundaries
+- [x] step 3: identify which prune modes need runtime delivery versus session delivery
+
+## Phase 2 — Implementation
+- [x] step 1: make `flushPending` return structured success and failure results
+- [x] step 2: guard concurrent flushes and restore pending batches on retry-safe failures
+- [x] step 3: use runtime delivery for active tool-loop flushes
+- [x] step 4: use captured session persistence for final-message flushes
+- [x] step 5: avoid queuing `context_prune` housekeeping results
+- [x] step 6: preserve captured tool arguments from `input`, `args`, or `arguments` fields
+
+## Phase 3 — Validation
+- [x] step 1: run TypeScript and diff hygiene checks
+- [x] step 2: verify `agentic-auto` pruning in live Pi
+- [x] step 3: verify `agent-message` pruning in live Pi
+- [x] step 4: verify `every-turn` pruning in live Pi
+- [x] step 5: verify `context_tree_query` recovers pruned output

--- a/index.ts
+++ b/index.ts
@@ -21,8 +21,8 @@ import { ToolCallIndexer } from "./src/indexer.js";
 import { pruneMessages } from "./src/pruner.js";
 import { registerQueryTool } from "./src/query-tool.js";
 import { registerCommands, pruneStatusText } from "./src/commands.js";
-import type { ContextPruneConfig, CapturedBatch } from "./src/types.js";
-import { STATUS_WIDGET_ID, CONTEXT_PRUNE_TOOL_NAME, AGENTIC_AUTO_SYSTEM_PROMPT } from "./src/types.js";
+import type { ContextPruneConfig, CapturedBatch, IndexEntryData } from "./src/types.js";
+import { STATUS_WIDGET_ID, CONTEXT_PRUNE_TOOL_NAME, AGENTIC_AUTO_SYSTEM_PROMPT, CUSTOM_TYPE_SUMMARY, CUSTOM_TYPE_INDEX, CUSTOM_TYPE_STATS } from "./src/types.js";
 import { StatsAccumulator } from "./src/stats.js";
 import { registerContextPruneTool } from "./src/context-prune-tool.js";
 
@@ -40,48 +40,176 @@ export default function (pi: ExtensionAPI) {
 
   // Pending batches — accumulated until the prune trigger fires
   const pendingBatches: CapturedBatch[] = [];
+  let isFlushing = false;
 
-  // Summarizes + indexes all pending batches in a single LLM call and injects steer messages.
-  // Called immediately in "every-turn" and "agentic-auto" modes, deferred otherwise.
-  const flushPending = async (ctx: any) => {
-    if (pendingBatches.length === 0) return;
-    const batches = pendingBatches.splice(0); // drain atomically
+  type FlushResult =
+    | { ok: true; reason: "flushed"; batchCount: number; toolCallCount: number }
+    | { ok: false; reason: "empty" | "already-flushing" | "summarizer-failed" | "stale-context" | "failed"; error?: string };
 
-    ctx.ui.setStatus(STATUS_WIDGET_ID, "prune: summarizing…");
+  type SessionAppender = {
+    appendCustomEntry(customType: string, data?: unknown): string;
+    appendCustomMessageEntry(customType: string, content: string, display: boolean, details?: unknown): string;
+  };
 
-    // Batch all pending batches into a single LLM call
-    const result = await summarizeBatches(batches, currentConfig.value, ctx);
+  const isStaleContextError = (err: unknown) =>
+    err instanceof Error && err.message.includes("This extension ctx is stale");
 
-    if (result) {
-      // Accumulate token/cost stats from this summarizer call
-      statsAccum.add(result.usage);
-      statsAccum.persist(pi);
+  const errorMessage = (err: unknown) => (err instanceof Error ? err.message : String(err));
 
-      // Index ALL batches and send one combined summary message
-      for (const batch of batches) {
-        indexer.addBatch(batch, pi);
-      }
+  const safeSetStatus = (ctx: any, text: string) => {
+    try {
+      ctx.ui.setStatus(STATUS_WIDGET_ID, text);
+    } catch (err) {
+      if (!isStaleContextError(err)) throw err;
+    }
+  };
 
-      const allToolCallIds = batches.flatMap((b) => b.toolCalls.map((tc) => tc.toolCallId));
-      const allToolNames = batches.flatMap((b) => b.toolCalls.map((tc) => tc.toolName));
+  const safeNotify = (ctx: any, message: string, type: "info" | "warning" | "error" = "info") => {
+    try {
+      ctx.ui.notify(message, type);
+    } catch (err) {
+      if (!isStaleContextError(err)) throw err;
+    }
+  };
 
-      pi.sendMessage(
-        {
-          customType: "context-prune-summary",
-          content: result.summaryText,
-          display: true,
-          details: {
-            toolCallIds: allToolCallIds,
-            toolNames: allToolNames,
-            turnIndex: batches[0].turnIndex, // first turn of the batch
-            timestamp: batches[batches.length - 1].timestamp, // last timestamp
-          },
-        },
-        { deliverAs: "steer" }
-      );
+  const assistantMessageHasToolCalls = (message: any) =>
+    message?.role === "assistant" &&
+    Array.isArray(message.content) &&
+    message.content.some((block: any) => block?.type === "toolCall");
+
+  const isFinalAssistantMessage = (message: any) => message?.role === "assistant" && !assistantMessageHasToolCalls(message);
+
+  const restoreBatches = (batches: CapturedBatch[]) => {
+    pendingBatches.unshift(...batches);
+  };
+
+  const persistBatchIndex = (batch: CapturedBatch, appendEntry: (customType: string, data?: unknown) => void) => {
+    const records = batch.toolCalls.map((tc) => ({
+      toolCallId: tc.toolCallId,
+      toolName: tc.toolName,
+      args: tc.args,
+      resultText: tc.resultText,
+      isError: tc.isError,
+      turnIndex: batch.turnIndex,
+      timestamp: batch.timestamp,
+    }));
+
+    for (const record of records) {
+      indexer.getIndex().set(record.toolCallId, record);
     }
 
-    ctx.ui.setStatus(STATUS_WIDGET_ID, pruneStatusText(currentConfig.value, statsAccum.getStats()));
+    appendEntry(CUSTOM_TYPE_INDEX, { toolCalls: records } as IndexEntryData);
+  };
+
+  // Summarizes + indexes all pending batches in a single LLM call.
+  // Runtime delivery is used while the agent/tool loop is active so Pi can place
+  // steer messages at protocol-safe boundaries. Session delivery is used only for
+  // agent-message's final-message flush, where print-mode Pi may invalidate pi.*
+  // while the summarizer LLM call is in flight.
+  const flushPending = async (ctx: any, options: { delivery?: "runtime" | "session" } = {}): Promise<FlushResult> => {
+    if (pendingBatches.length === 0) return { ok: false, reason: "empty" };
+    if (isFlushing) return { ok: false, reason: "already-flushing" };
+
+    const batches = pendingBatches.splice(0); // drain atomically; restore on failure
+    const toolCallCount = batches.reduce((sum, batch) => sum + batch.toolCalls.length, 0);
+    isFlushing = true;
+
+    const delivery = options.delivery ?? "runtime";
+    let sessionManager: SessionAppender | undefined;
+    if (delivery === "session") {
+      try {
+        sessionManager = ctx.sessionManager as unknown as SessionAppender;
+      } catch (err) {
+        restoreBatches(batches);
+        isFlushing = false;
+        return { ok: false, reason: isStaleContextError(err) ? "stale-context" : "failed", error: errorMessage(err) };
+      }
+    }
+
+    const appendEntry = (customType: string, data?: unknown) => sessionManager!.appendCustomEntry(customType, data);
+    const appendSummaryMessage = (content: string, details: unknown) =>
+      sessionManager!.appendCustomMessageEntry(CUSTOM_TYPE_SUMMARY, content, true, details);
+
+    try {
+      safeSetStatus(ctx, "prune: summarizing…");
+
+      // Batch all pending batches into a single LLM call
+      const result = await summarizeBatches(batches, currentConfig.value, ctx);
+
+      if (!result) {
+        restoreBatches(batches);
+        safeSetStatus(ctx, pruneStatusText(currentConfig.value, statsAccum.getStats()));
+        return { ok: false, reason: "summarizer-failed" };
+      }
+
+      try {
+        const allToolCallIds = batches.flatMap((b) => b.toolCalls.map((tc) => tc.toolCallId));
+        const allToolNames = batches.flatMap((b) => b.toolCalls.map((tc) => tc.toolName));
+        const details = {
+          toolCallIds: allToolCallIds,
+          toolNames: allToolNames,
+          turnIndex: batches[0].turnIndex, // first turn of the batch
+          timestamp: batches[batches.length - 1].timestamp, // last timestamp
+        };
+
+        if (delivery === "runtime") {
+          statsAccum.add(result.usage);
+          statsAccum.persist(pi);
+
+          for (const batch of batches) {
+            indexer.addBatch(batch, pi);
+          }
+
+          pi.sendMessage(
+            {
+              customType: CUSTOM_TYPE_SUMMARY,
+              content: result.summaryText,
+              display: true,
+              details,
+            },
+            { deliverAs: "steer" }
+          );
+        } else {
+          let wroteSessionEntry = false;
+          try {
+            // Persist the visible summary before the index that activates pruning.
+            // If persistence ever fails partway through, the safer partial state is
+            // a summary without pruning rather than pruning without a summary.
+            appendSummaryMessage(result.summaryText, details);
+            wroteSessionEntry = true;
+
+            for (const batch of batches) {
+              persistBatchIndex(batch, appendEntry);
+            }
+
+            statsAccum.add(result.usage);
+            try {
+              appendEntry(CUSTOM_TYPE_STATS, statsAccum.getStats());
+            } catch {
+              // Ignore stats persistence failures; the summary and index are the contract.
+            }
+          } catch (err) {
+            if (!wroteSessionEntry) restoreBatches(batches);
+            return { ok: false, reason: isStaleContextError(err) ? "stale-context" : "failed", error: errorMessage(err) };
+          }
+        }
+      } catch (err) {
+        restoreBatches(batches);
+        return { ok: false, reason: isStaleContextError(err) ? "stale-context" : "failed", error: errorMessage(err) };
+      }
+
+      safeSetStatus(ctx, pruneStatusText(currentConfig.value, statsAccum.getStats()));
+      return { ok: true, reason: "flushed", batchCount: batches.length, toolCallCount };
+    } catch (err) {
+      restoreBatches(batches);
+      if (isStaleContextError(err)) {
+        return { ok: false, reason: "stale-context", error: errorMessage(err) };
+      }
+      safeNotify(ctx, `pruner: summarization failed: ${errorMessage(err)}`, "error");
+      return { ok: false, reason: "failed", error: errorMessage(err) };
+    } finally {
+      isFlushing = false;
+    }
   };
 
   // ── Helper: toggle context_prune tool activation based on config ───────────
@@ -142,26 +270,31 @@ export default function (pi: ExtensionAPI) {
     const hasToolResults = event.toolResults && event.toolResults.length > 0;
 
     if (!hasToolResults) {
-      // Text-only turn: the agent sent a final message with no tool calls.
-      // In "agent-message" mode, this is the trigger to flush pending batches.
-      if (currentConfig.value.pruneOn === "agent-message") {
-        await flushPending(ctx);
-      }
+      // Text-only final turns are handled by message_end in agent-message mode.
+      // In print mode, turn_end can fire after session shutdown, so do not start
+      // deferred LLM work from this late lifecycle event.
       return;
     }
 
-    const batch = captureBatch(
+    const capturedBatch = captureBatch(
       event.message,
       event.toolResults,
       event.turnIndex,
       Date.now()
     );
+    const batch = {
+      ...capturedBatch,
+      // Do not summarize the pruner's own housekeeping tool result. Otherwise
+      // agentic-auto mode can queue the context_prune result and try to flush it
+      // during agent_end, when Pi may already have invalidated the extension ctx.
+      toolCalls: capturedBatch.toolCalls.filter((tc) => tc.toolName !== CONTEXT_PRUNE_TOOL_NAME),
+    };
     if (batch.toolCalls.length === 0) return;
 
     pendingBatches.push(batch);
 
     if (currentConfig.value.pruneOn === "every-turn") {
-      await flushPending(ctx);
+      await flushPending(ctx, { delivery: "session" });
     } else {
       // Let the user know a batch is queued
       const n = pendingBatches.length;
@@ -180,8 +313,9 @@ export default function (pi: ExtensionAPI) {
           trigger = "/pruner now";
           break;
       }
-      ctx.ui.setStatus(STATUS_WIDGET_ID, `prune: ${n} pending`);
-      ctx.ui.notify(
+      safeSetStatus(ctx, `prune: ${n} pending`);
+      safeNotify(
+        ctx,
         `pruner: ${n} turn${n === 1 ? "" : "s"} queued — will summarize on ${trigger}`,
         "info"
       );
@@ -193,17 +327,28 @@ export default function (pi: ExtensionAPI) {
     if (event.toolName !== "context_tag") return;
     if (!currentConfig.value.enabled) return;
     if (currentConfig.value.pruneOn !== "on-context-tag") return;
-    await flushPending(ctx);
+    await flushPending(ctx, { delivery: "runtime" });
   });
 
-  // ── agent_end: safety net flush for agent-message and agentic-auto modes ──────
-  // If the agent loop ends before a trigger fires (e.g. aborted),
-  // flush any remaining pending batches so they aren't lost.
+  // ── message_end: flush after the final assistant response in agent-message mode ──
+  // A final assistant message is the earliest reliable boundary where the agent has
+  // finished using the raw tool results. flushPending captures the SessionManager
+  // before awaiting summarization so print-mode shutdown cannot invalidate the
+  // persistence path while the summarizer model is running.
+  pi.on("message_end", async (event, ctx) => {
+    if (!currentConfig.value.enabled) return;
+    if (currentConfig.value.pruneOn !== "agent-message") return;
+    if (!isFinalAssistantMessage(event.message)) return;
+    await flushPending(ctx, { delivery: "session" });
+  });
+
+  // ── agent_end: last-chance cleanup only ─────────────────────────────────────
+  // agent-message normally flushes on message_end. By agent_end, print-mode Pi may
+  // already be disposing the session, so avoid starting a best-effort LLM call here.
   pi.on("agent_end", async (_event, ctx) => {
     if (!currentConfig.value.enabled) return;
-    if (currentConfig.value.pruneOn !== "agent-message" && currentConfig.value.pruneOn !== "agentic-auto") return;
     if (pendingBatches.length === 0) return;
-    await flushPending(ctx);
+    safeSetStatus(ctx, `prune: ${pendingBatches.length} pending`);
   });
 
   // ── context: prune summarized tool results from next LLM call ─────────────
@@ -232,7 +377,7 @@ export default function (pi: ExtensionAPI) {
   registerQueryTool(pi, indexer);
 
   // ── Register context_prune tool (always registered, activated only in agentic-auto mode) ──
-  registerContextPruneTool(pi, flushPending);
+  registerContextPruneTool(pi, (ctx) => flushPending(ctx, { delivery: "runtime" }));
 
   // ── Register /pruner command + summary message renderer ────────────
   registerCommands(pi, currentConfig, flushPending, syncToolActivation, () => statsAccum.getStats(), indexer);

--- a/src/batch-capture.ts
+++ b/src/batch-capture.ts
@@ -41,7 +41,7 @@ export function captureBatch(
       return {
         toolCallId: block.id,
         toolName: block.name,
-        args: block.input ?? block.args ?? {},
+        args: block.input ?? block.args ?? block.arguments ?? {},
         resultText,
         isError,
       } satisfies CapturedToolCall;

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -7,7 +7,7 @@ import {
 import type { ExtensionAPI, ExtensionCommandContext } from "@mariozechner/pi-coding-agent";
 import { saveConfig } from "./config.js";
 import { formatTokens, formatCost } from "./stats.js";
-import { Container, type Component, Text, SettingsList, type SettingItem } from "@mariozechner/pi-tui";
+import { Container, Text, SettingsList, type SettingItem } from "@mariozechner/pi-tui";
 import { DynamicBorder, getSettingsListTheme } from "@mariozechner/pi-coding-agent";
 import { buildPruneTree, TreeBrowser } from "./tree-browser.js";
 import type { ToolCallIndexer } from "./indexer.js";
@@ -127,7 +127,7 @@ Settings are saved to ~/.pi/agent/context-prune/settings.json`;
 export function registerCommands(
   pi: ExtensionAPI,
   currentConfig: { value: ContextPruneConfig },
-  flushPending: (ctx: ExtensionCommandContext) => void,
+  flushPending: (ctx: ExtensionCommandContext) => Promise<{ ok: boolean; reason: string; error?: string }>,
   syncToolActivation: () => void,
   getStats: () => SummarizerStats,
   indexer: ToolCallIndexer,
@@ -235,28 +235,23 @@ export function registerCommands(
             syncToolActivation();
           };
 
+          let closeSettingsOverlay = () => {};
           settingsList = new SettingsList(
             items,
             10,
             getSettingsListTheme(),
             onChange,
-            () => {}, // onCancel — just close the overlay
+            () => closeSettingsOverlay(), // onCancel — close the custom overlay
             { enableSearch: false },
           );
 
           // Use ctx.ui.custom() to show the settings list as an overlay.
           // The factory receives (tui, theme, keybindings, done) and returns a Component.
-          // When done() is called (by pressing Escape via SettingsList's onCancel),
-          // the custom UI closes and the promise resolves.
+          // Wire Escape through the SettingsList constructor's onCancel callback instead
+          // of mutating private SettingsList fields.
           await ctx.ui.custom(
             (_tui, _theme, _keybindings, done) => {
-              // Wrap onCancel to call done() so the custom UI closes when Escape is pressed
-              const originalOnCancel = settingsList.onCancel;
-              settingsList.onCancel = () => {
-                originalOnCancel();
-                done(undefined);
-              };
-
+              closeSettingsOverlay = () => done(undefined);
               return new SettingsOverlay("pruner settings", settingsList);
             },
             {
@@ -373,7 +368,11 @@ export function registerCommands(
             ctx.ui.notify("Context pruning is disabled. Run /pruner on first.", "warning");
             return;
           }
-          flushPending(ctx);
+          const result = await flushPending(ctx);
+          if (!result.ok) {
+            const suffix = result.error ? ` (${result.error})` : "";
+            ctx.ui.notify(`pruner: nothing flushed — ${result.reason}${suffix}`, result.reason === "empty" ? "info" : "warning");
+          }
           break;
         }
 

--- a/src/context-prune-tool.ts
+++ b/src/context-prune-tool.ts
@@ -18,9 +18,13 @@ import { CONTEXT_PRUNE_TOOL_NAME } from "./types.js";
  * @param pi      Extension API for tool registration
  * @param flushPending  Shared flush function that summarizes + indexes pending batches
  */
+type FlushResult =
+  | { ok: true; reason: "flushed"; batchCount: number; toolCallCount: number }
+  | { ok: false; reason: string; error?: string };
+
 export function registerContextPruneTool(
   pi: ExtensionAPI,
-  flushPending: (ctx: ExtensionContext) => Promise<void>,
+  flushPending: (ctx: ExtensionContext) => Promise<FlushResult>,
 ): void {
   pi.registerTool({
     name: CONTEXT_PRUNE_TOOL_NAME,
@@ -39,14 +43,28 @@ export function registerContextPruneTool(
 
     async execute(_toolCallId, _params, _signal, _onUpdate, ctx) {
       try {
-        await flushPending(ctx);
+        const result = await flushPending(ctx);
+        if (!result.ok) {
+          const suffix = result.error ? ` (${result.error})` : "";
+          return {
+            content: [
+              {
+                type: "text",
+                text: `Context prune did not run: ${result.reason}${suffix}.`,
+              },
+            ],
+            details: result,
+          };
+        }
+
         return {
           content: [
             {
               type: "text",
-              text: "Context prune completed. Pending tool-call results have been summarized and pruned from context. Use context_tree_query with the toolCallIds from the summary to retrieve full outputs if needed.",
+              text: `Context prune completed. Summarized ${result.toolCallCount} tool call${result.toolCallCount === 1 ? "" : "s"} from ${result.batchCount} batch${result.batchCount === 1 ? "" : "es"}. Use context_tree_query with the toolCallIds from the summary to retrieve full outputs if needed.`,
             },
           ],
+          details: result,
         };
       } catch (err: any) {
         return {
@@ -56,6 +74,7 @@ export function registerContextPruneTool(
               text: `Context prune failed: ${err.message}`,
             },
           ],
+          details: { ok: false, reason: "failed", error: err.message },
         };
       }
     },


### PR DESCRIPTION
## Summary

`pi-context-prune` could hit stale extension context errors when it tried to flush pending tool results near the end of an agent run.

The common case was print/non-interactive mode: pruning starts, the summarizer model runs, and by the time control returns, Pi may already be tearing down or replacing the session context. At that point calls through the extension runtime can fail with:

```text
Extension ctx is stale after session replacement or reload
```

This patch makes pruning finish through the right boundary for the situation:

- while the agent/tool loop is still active, keep using normal runtime delivery
- at final-message boundaries, persist through the session manager captured before awaiting the summarizer

It also avoids re-queuing the `context_prune` tool’s own result, which could otherwise create a pointless late flush.

## Validation

```bash
npx tsc --noEmit --moduleResolution bundler --module esnext --target es2022 --skipLibCheck index.ts src/*.ts
git diff --check
npm run check
```

Live Pi checks covered:

- `agentic-auto` pruning
- `agent-message` pruning
- `every-turn` pruning
- `context_tree_query` recovery
- no stale context errors from `pi-context-prune`
