### PR TITLE
Add configurable thinking level for summarizer calls

### DIFF
--- a/.agents/plans/014-add-summarizer-thinking-level.md
+++ b/.agents/plans/014-add-summarizer-thinking-level.md
@@ -1,0 +1,39 @@
+---
+name: 014-add-summarizer-thinking-level
+description: Add a configurable thinking level for pruning summarizer calls while preserving existing defaults.
+steps:
+  - phase: discovery
+    steps:
+      - "- [x] step 1: clone upstream main into an independent worktree and create the feature branch"
+      - "- [x] step 2: inspect repo guidance, current config, command, summarizer, and pi-ai reasoning option behavior"
+  - phase: implementation
+    steps:
+      - "- [x] step 1: add summarizer thinking types, defaults, and config validation"
+      - "- [x] step 2: pass configured thinking options to summarizer LLM calls"
+      - "- [x] step 3: expose the setting through /pruner status, commands, help, and settings overlay"
+      - "- [x] step 4: support /pruner model <id>:<thinking> shorthand"
+      - "- [x] step 5: document the setting and provider caveats in README"
+  - phase: validation
+    steps:
+      - "- [x] step 1: run TypeScript/static checks and diff whitespace checks"
+      - "- [x] step 2: run feasible live Pi checks for default/minimal/invalid settings"
+      - "- [x] step 3: review the final diff and update the plan"
+---
+
+# 014-add-summarizer-thinking-level
+
+## Phase 1 — Discovery
+- [x] step 1: clone upstream main into an independent worktree and create the feature branch
+- [x] step 2: inspect repo guidance, current config, command, summarizer, and pi-ai reasoning option behavior
+
+## Phase 2 — Implementation
+- [x] step 1: add summarizer thinking types, defaults, and config validation
+- [x] step 2: pass configured thinking options to summarizer LLM calls
+- [x] step 3: expose the setting through /pruner status, commands, help, and settings overlay
+- [x] step 4: support /pruner model <id>:<thinking> shorthand
+- [x] step 5: document the setting and provider caveats in README
+
+## Phase 3 — Validation
+- [x] step 1: run TypeScript/static checks and diff whitespace checks
+- [x] step 2: run feasible live Pi checks for default/minimal/invalid settings
+- [x] step 3: review the final diff and update the plan

--- a/README.md
+++ b/README.md
@@ -128,9 +128,12 @@ The extension registers the `/pruner` command:
 | `/pruner settings` | Opens an interactive settings overlay |
 | `/pruner on` | Enable pruning |
 | `/pruner off` | Disable pruning |
-| `/pruner status` | Show enabled state, summarizer model, prune trigger, and cumulative stats |
+| `/pruner status` | Show enabled state, summarizer model, thinking level, prune trigger, and cumulative stats |
 | `/pruner model` | Show current summarizer model |
 | `/pruner model <id>` | Set summarizer model (e.g. `anthropic/claude-haiku-3-5`) |
+| `/pruner model <id>:<thinking>` | Set summarizer model and thinking together (e.g. `openai/gpt-5-mini:low`) |
+| `/pruner thinking` | Show current summarizer thinking level |
+| `/pruner thinking <level>` | Set summarizer thinking (`default`, `off`, `minimal`, `low`, `medium`, `high`, `xhigh`) |
 | `/pruner prune-on` | Interactive picker over all trigger modes |
 | `/pruner prune-on <mode>` | Set trigger mode directly |
 | `/pruner stats` | Show cumulative summarizer token/cost stats |
@@ -140,11 +143,12 @@ The extension registers the `/pruner` command:
 
 ### Settings overlay
 
-`/pruner settings` opens a TUI overlay with three interactive items:
+`/pruner settings` opens a TUI overlay with four interactive items:
 
 1. **Enabled** — toggle pruning on/off
 2. **Prune trigger** — cycle through all five `pruneOn` modes
 3. **Summarizer model** — press Enter to open a searchable submenu listing `"default"` plus all available models
+4. **Summarizer thinking** — cycle through the thinking/reasoning level used for summarizer calls
 
 All changes are saved immediately to `~/.pi/agent/context-prune/settings.json` and reflected in the footer status widget.
 
@@ -180,6 +184,7 @@ Config is stored in `~/.pi/agent/context-prune/settings.json` (global, project-i
 {
   "enabled": false,
   "summarizerModel": "default",
+  "summarizerThinking": "default",
   "pruneOn": "agent-message"
 }
 ```
@@ -188,9 +193,13 @@ Config is stored in `~/.pi/agent/context-prune/settings.json` (global, project-i
 |---|---|---|
 | `enabled` | `true` / `false` | `false` |
 | `summarizerModel` | `"default"` or `"provider/model-id"` | `"default"` |
+| `summarizerThinking` | `"default"`, `"off"`, `"minimal"`, `"low"`, `"medium"`, `"high"`, `"xhigh"` | `"default"` |
 | `pruneOn` | `"every-turn"`, `"on-context-tag"`, `"on-demand"`, `"agent-message"`, `"agentic-auto"` | `"agent-message"` |
 
-- `"default"` means the current active Pi model. An explicit value like `"anthropic/claude-haiku-3-5"` uses that model for summarization (must be registered in Pi and have an API key).
+- `summarizerModel: "default"` means the current active Pi model. An explicit value like `"anthropic/claude-haiku-3-5"` uses that model for summarization (must be registered in Pi and have an API key).
+- `summarizerThinking: "default"` preserves old behavior: no explicit thinking/reasoning option is added to summarizer calls.
+- `summarizerThinking: "off"` requests no summarizer reasoning where the provider adapter supports an explicit disable path. Some providers may still fall back to their own default behavior.
+- `"minimal"`, `"low"`, `"medium"`, `"high"`, and `"xhigh"` request that thinking level for summarizer calls where supported. For cheap background summarization, prefer `"minimal"` or `"low"` with a small/fast model.
 - Settings are persisted on every change via the `/pruner` command or the settings overlay.
 
 ### Choosing a Summarizer Model
@@ -210,7 +219,12 @@ Set it with:
 
 ```bash
 /pruner model openai/gpt-4.1-mini
-# or via the interactive settings overlay
+/pruner thinking low
+
+# Or set both at once:
+/pruner model openai/gpt-4.1-mini:low
+
+# Or via the interactive settings overlay
 /pruner settings
 ```
 
@@ -218,7 +232,8 @@ Or directly in `~/.pi/agent/context-prune/settings.json`:
 
 ```json
 {
-  "summarizerModel": "openrouter/qwen/qwen3-30b-a3b"
+  "summarizerModel": "openrouter/qwen/qwen3-30b-a3b",
+  "summarizerThinking": "low"
 }
 ```
 

--- a/index.ts
+++ b/index.ts
@@ -22,14 +22,14 @@ import { pruneMessages } from "./src/pruner.js";
 import { registerQueryTool } from "./src/query-tool.js";
 import { registerCommands, pruneStatusText } from "./src/commands.js";
 import type { ContextPruneConfig, CapturedBatch } from "./src/types.js";
-import { STATUS_WIDGET_ID, CONTEXT_PRUNE_TOOL_NAME, AGENTIC_AUTO_SYSTEM_PROMPT } from "./src/types.js";
+import { DEFAULT_CONFIG, STATUS_WIDGET_ID, CONTEXT_PRUNE_TOOL_NAME, AGENTIC_AUTO_SYSTEM_PROMPT } from "./src/types.js";
 import { StatsAccumulator } from "./src/stats.js";
 import { registerContextPruneTool } from "./src/context-prune-tool.js";
 
 export default function (pi: ExtensionAPI) {
   // Shared mutable config reference — updated by /pruner commands
   const currentConfig: { value: ContextPruneConfig } = {
-    value: { enabled: false, summarizerModel: "default", pruneOn: "every-turn" },
+    value: { ...DEFAULT_CONFIG, pruneOn: "every-turn" },
   };
 
   // Shared indexer — rebuilt from session on every session_start / session_tree

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -3,6 +3,7 @@ import {
   type SummarizerStats,
   PRUNE_ON_MODES,
   STATUS_WIDGET_ID,
+  SUMMARIZER_THINKING_LEVELS,
 } from "./types.js";
 import type { ExtensionAPI, ExtensionCommandContext } from "@mariozechner/pi-coding-agent";
 import { saveConfig } from "./config.js";
@@ -55,8 +56,9 @@ const SUBCOMMANDS = [
   { value: "settings", label: "settings — interactive settings overlay" },
   { value: "on",       label: "on       — enable context pruning" },
   { value: "off",      label: "off      — disable context pruning" },
-  { value: "status",  label: "status   — show status, model, and prune trigger" },
+  { value: "status",  label: "status   — show status, model, thinking, and prune trigger" },
   { value: "model",   label: "model    — show or set the summarizer model" },
+  { value: "thinking", label: "thinking — show or set the summarizer thinking level" },
   { value: "prune-on", label: "prune-on — show or set the trigger mode" },
   { value: "stats",   label: "stats    — show cumulative summarizer token/cost stats" },
   { value: "tree",    label: "tree     — browse pruned tool calls in a foldable tree" },
@@ -82,6 +84,40 @@ function pruneModeLabel(mode: ContextPruneConfig["pruneOn"]): string {
   return PRUNE_ON_MODES.find((entry) => entry.value === mode)?.label ?? mode;
 }
 
+function summarizerThinkingLabel(level: ContextPruneConfig["summarizerThinking"]): string {
+  return SUMMARIZER_THINKING_LEVELS.find((entry) => entry.value === level)?.label ?? level;
+}
+
+function summarizerThinkingDescription(level: ContextPruneConfig["summarizerThinking"]): string {
+  if (level === "default") {
+    return "Preserve old behavior: send no explicit thinking option for summarizer calls.";
+  }
+  if (level === "off") {
+    return "Request no summarizer reasoning where the provider adapter supports it; some providers may fall back to their default.";
+  }
+  return `Request ${level} thinking/reasoning for summarizer calls where supported.`;
+}
+
+function parseModelAndThinkingArg(
+  value: string,
+): { model: string; thinking?: ContextPruneConfig["summarizerThinking"]; error?: string } {
+  const separatorIndex = value.lastIndexOf(":");
+  if (separatorIndex === -1) {
+    return { model: value };
+  }
+
+  const model = value.slice(0, separatorIndex);
+  const suffix = value.slice(separatorIndex + 1);
+  const thinking = SUMMARIZER_THINKING_LEVELS.find((level) => level.value === suffix)?.value;
+  if (!model || !thinking) {
+    return {
+      model: value,
+      error: `Invalid model thinking suffix: ${suffix}. Use one of: ${SUMMARIZER_THINKING_LEVELS.map((level) => level.value).join(", ")}.`,
+    };
+  }
+  return { model, thinking };
+}
+
 function pruneTriggerDescription(mode: ContextPruneConfig["pruneOn"]): string {
   return `When to summarize tool outputs. Current mode: ${pruneModeLabel(mode)} (${mode}) — ${pruneModeGuidance(mode)} Press Enter/Space to cycle through modes.`;
 }
@@ -95,6 +131,9 @@ Usage:
   /pruner status                           Show status, model, prune trigger, and stats
   /pruner model                            Show the current summarizer model
   /pruner model <id>                       Set summarizer model (e.g. anthropic/claude-haiku-3-5)
+  /pruner model <id>:<thinking>            Set summarizer model and thinking together (e.g. openai/gpt-5-mini:low)
+  /pruner thinking                         Show the current summarizer thinking level
+  /pruner thinking <level>                 Set summarizer thinking: default, off, minimal, low, medium, high, xhigh
   /pruner prune-on                         Show or interactively pick the trigger
   /pruner prune-on every-turn              Summarize after every tool-calling turn (debugging only; worst for prompt cache churn)
   /pruner prune-on on-context-tag          Summarize when context_tag is called (requires pi-context extension)
@@ -210,9 +249,17 @@ export function registerCommands(
                 );
               },
             },
+            {
+              id: "summarizerThinking",
+              label: "Summarizer thinking",
+              values: SUMMARIZER_THINKING_LEVELS.map((level) => level.value),
+              currentValue: config.summarizerThinking,
+              description: summarizerThinkingDescription(config.summarizerThinking),
+            },
           ];
 
           let settingsList: SettingsList;
+          let closeSettingsOverlay = () => {};
 
           const onChange = (id: string, newValue: string) => {
             const newConfig = { ...currentConfig.value };
@@ -226,6 +273,12 @@ export function registerCommands(
               }
             } else if (id === "summarizerModel") {
               newConfig.summarizerModel = newValue;
+            } else if (id === "summarizerThinking") {
+              newConfig.summarizerThinking = newValue as ContextPruneConfig["summarizerThinking"];
+              const thinkingItem = items.find((item) => item.id === "summarizerThinking");
+              if (thinkingItem) {
+                thinkingItem.description = summarizerThinkingDescription(newConfig.summarizerThinking);
+              }
             }
             currentConfig.value = newConfig;
             saveConfig(newConfig);
@@ -240,7 +293,7 @@ export function registerCommands(
             10,
             getSettingsListTheme(),
             onChange,
-            () => {}, // onCancel — just close the overlay
+            () => closeSettingsOverlay(), // onCancel — close the overlay
             { enableSearch: false },
           );
 
@@ -250,13 +303,7 @@ export function registerCommands(
           // the custom UI closes and the promise resolves.
           await ctx.ui.custom(
             (_tui, _theme, _keybindings, done) => {
-              // Wrap onCancel to call done() so the custom UI closes when Escape is pressed
-              const originalOnCancel = settingsList.onCancel;
-              settingsList.onCancel = () => {
-                originalOnCancel();
-                done(undefined);
-              };
-
+              closeSettingsOverlay = () => done(undefined);
               return new SettingsOverlay("pruner settings", settingsList);
             },
             {
@@ -296,7 +343,7 @@ export function registerCommands(
             ? `\n  --- summarizer ---\n  calls:       ${s.callCount}\n  input:       ${formatTokens(s.totalInputTokens)} tokens\n  output:      ${formatTokens(s.totalOutputTokens)} tokens\n  cost:        ${formatCost(s.totalCost)}`
             : "\n  (no summarizer calls yet)";
           ctx.ui.notify(
-            `pruner status:\n  enabled: ${cfg.enabled}\n  model:   ${cfg.summarizerModel}\n  trigger: ${mode}${statsLine}`,
+            `pruner status:\n  enabled:  ${cfg.enabled}\n  model:    ${cfg.summarizerModel}\n  thinking: ${summarizerThinkingLabel(cfg.summarizerThinking)} (${cfg.summarizerThinking})\n  trigger:  ${mode}${statsLine}`,
           );
           break;
         }
@@ -339,12 +386,50 @@ export function registerCommands(
         case "model": {
           const modelArg = subArgs[0];
           if (!modelArg) {
-            ctx.ui.notify(`Current summarizer model: ${currentConfig.value.summarizerModel}`);
+            ctx.ui.notify(
+              `Current summarizer model: ${currentConfig.value.summarizerModel}\nCurrent summarizer thinking: ${summarizerThinkingLabel(currentConfig.value.summarizerThinking)} (${currentConfig.value.summarizerThinking})`,
+            );
           } else {
-            currentConfig.value = { ...currentConfig.value, summarizerModel: modelArg };
+            const parsed = parseModelAndThinkingArg(modelArg);
+            if (parsed.error) {
+              ctx.ui.notify(parsed.error, "warning");
+              return;
+            }
+            currentConfig.value = {
+              ...currentConfig.value,
+              summarizerModel: parsed.model,
+              summarizerThinking: parsed.thinking ?? currentConfig.value.summarizerThinking,
+            };
             saveConfig(currentConfig.value);
-            ctx.ui.notify(`Summarizer model set to: ${modelArg}`);
+            const thinkingText = parsed.thinking ? ` with thinking ${parsed.thinking}` : "";
+            ctx.ui.notify(`Summarizer model set to: ${parsed.model}${thinkingText}`);
           }
+          break;
+        }
+
+        // ── /pruner thinking [value] ──
+        case "thinking": {
+          const thinkingArg = subArgs[0];
+          if (!thinkingArg) {
+            ctx.ui.notify(
+              `Current summarizer thinking: ${summarizerThinkingLabel(currentConfig.value.summarizerThinking)} (${currentConfig.value.summarizerThinking})`,
+            );
+            return;
+          }
+          if (SUMMARIZER_THINKING_LEVELS.some((level) => level.value === thinkingArg)) {
+            currentConfig.value = {
+              ...currentConfig.value,
+              summarizerThinking: thinkingArg as ContextPruneConfig["summarizerThinking"],
+            };
+          } else {
+            ctx.ui.notify(
+              `Invalid summarizer thinking level: ${thinkingArg}. Use one of: ${SUMMARIZER_THINKING_LEVELS.map((level) => level.value).join(", ")}.`,
+              "warning",
+            );
+            return;
+          }
+          saveConfig(currentConfig.value);
+          ctx.ui.notify(`Summarizer thinking set to: ${currentConfig.value.summarizerThinking}`);
           break;
         }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,18 +1,33 @@
 import { readFile, writeFile, mkdir } from "node:fs/promises";
 import { join, dirname } from "node:path";
 import { homedir } from "node:os";
-import type { ContextPruneConfig } from "./types.js";
-import { DEFAULT_CONFIG } from "./types.js";
+import type { ContextPruneConfig, PruneOn, SummarizerThinking } from "./types.js";
+import { DEFAULT_CONFIG, PRUNE_ON_MODES, SUMMARIZER_THINKING_LEVELS } from "./types.js";
 
 /** Path to the extension's own settings file, independent of any project. */
 export const SETTINGS_PATH = join(homedir(), ".pi", "agent", "context-prune", "settings.json");
+
+function isPruneOn(value: unknown): value is PruneOn {
+  return typeof value === "string" && PRUNE_ON_MODES.some((mode) => mode.value === value);
+}
+
+function isSummarizerThinking(value: unknown): value is SummarizerThinking {
+  return typeof value === "string" && SUMMARIZER_THINKING_LEVELS.some((level) => level.value === value);
+}
 
 /** Reads ~/.pi/agent/context-prune/settings.json and returns the config (or defaults). */
 export async function loadConfig(): Promise<ContextPruneConfig> {
   try {
     const raw = await readFile(SETTINGS_PATH, "utf-8");
     const existing = JSON.parse(raw);
-    return { ...DEFAULT_CONFIG, ...existing };
+    const merged = { ...DEFAULT_CONFIG, ...existing };
+    return {
+      ...merged,
+      pruneOn: isPruneOn(merged.pruneOn) ? merged.pruneOn : DEFAULT_CONFIG.pruneOn,
+      summarizerThinking: isSummarizerThinking(merged.summarizerThinking)
+        ? merged.summarizerThinking
+        : DEFAULT_CONFIG.summarizerThinking,
+    };
   } catch {
     return { ...DEFAULT_CONFIG };
   }

--- a/src/context-prune-tool.ts
+++ b/src/context-prune-tool.ts
@@ -47,6 +47,7 @@ export function registerContextPruneTool(
               text: "Context prune completed. Pending tool-call results have been summarized and pruned from context. Use context_tree_query with the toolCallIds from the summary to retrieve full outputs if needed.",
             },
           ],
+          details: {},
         };
       } catch (err: any) {
         return {
@@ -56,6 +57,7 @@ export function registerContextPruneTool(
               text: `Context prune failed: ${err.message}`,
             },
           ],
+          details: {},
         };
       }
     },

--- a/src/summarizer.ts
+++ b/src/summarizer.ts
@@ -1,6 +1,6 @@
 import { complete } from "@mariozechner/pi-ai";
 import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
-import type { CapturedBatch, ContextPruneConfig, SummarizeResult } from "./types.js";
+import type { CapturedBatch, ContextPruneConfig, SummarizerThinking, SummarizeResult } from "./types.js";
 import { serializeBatchForSummarizer, serializeBatchesForSummarizer } from "./batch-capture.js";
 
 const SYSTEM_PROMPT = `You are summarizing a batch of tool calls made by an AI coding assistant.
@@ -19,6 +19,19 @@ For each turn, provide a concise summary of all tool calls in that turn:
 - Any findings the future conversation needs to remember
 
 Keep each tool call to 1-3 bullet points. Group by turn. Be concise.`;
+
+export function summarizerThinkingOptions(config: ContextPruneConfig): Record<string, unknown> {
+  const level: SummarizerThinking = config.summarizerThinking;
+  if (level === "default") {
+    return {};
+  }
+
+  // complete() accepts provider-level options. For reasoning-capable providers,
+  // pi-ai adapters translate reasoningEffort into the provider-specific field.
+  // "off" intentionally sends no effort; adapters that support explicit disable
+  // handle that the same way as an absent effort, while preserving compatibility.
+  return { reasoningEffort: level === "off" ? undefined : level };
+}
 
 /**
  * Returns the model to use for summarization.
@@ -87,7 +100,7 @@ export async function summarizeBatch(
           },
         ],
       },
-      { apiKey: auth.apiKey, headers: auth.headers }
+      { apiKey: auth.apiKey, headers: auth.headers, ...summarizerThinkingOptions(config) }
     );
 
     const llmText = response.content
@@ -152,7 +165,7 @@ export async function summarizeBatches(
           },
         ],
       },
-      { apiKey: auth.apiKey, headers: auth.headers }
+      { apiKey: auth.apiKey, headers: auth.headers, ...summarizerThinkingOptions(config) }
     );
 
     const llmText = response.content

--- a/src/types.ts
+++ b/src/types.ts
@@ -95,6 +95,20 @@ What happens when you call context_prune:
  */
 export type PruneOn = "every-turn" | "on-context-tag" | "on-demand" | "agent-message" | "agentic-auto";
 
+/** Thinking/reasoning level requested for summarizer LLM calls. */
+export type SummarizerThinking = "default" | "off" | "minimal" | "low" | "medium" | "high" | "xhigh";
+
+/** Choices for the summarizer thinking setting (used by commands and settings overlay) */
+export const SUMMARIZER_THINKING_LEVELS: { value: SummarizerThinking; label: string }[] = [
+  { value: "default", label: "Default" },
+  { value: "off", label: "Off" },
+  { value: "minimal", label: "Minimal" },
+  { value: "low", label: "Low" },
+  { value: "medium", label: "Medium" },
+  { value: "high", label: "High" },
+  { value: "xhigh", label: "XHigh" },
+];
+
 /** Choices for the prune-on setting (used by commands and settings overlay) */
 export const PRUNE_ON_MODES: { value: PruneOn; label: string }[] = [
   { value: "every-turn", label: "Every turn" },
@@ -114,6 +128,8 @@ export interface ContextPruneConfig {
    * "provider/model-id" = explicit model (e.g. "anthropic/claude-haiku-3-5")
    */
   summarizerModel: string;
+  /** Thinking/reasoning level to request for summarizer calls. */
+  summarizerThinking: SummarizerThinking;
   /** When to trigger summarization and pruning */
   pruneOn: PruneOn;
 }
@@ -121,6 +137,7 @@ export interface ContextPruneConfig {
 export const DEFAULT_CONFIG: ContextPruneConfig = {
   enabled: false,
   summarizerModel: "default",
+  summarizerThinking: "default",
   pruneOn: "agent-message",
 };
 


### PR DESCRIPTION
## Summary
- Add a `summarizerThinking` config option for context-prune summarizer LLM calls, defaulting to `"default"` to preserve existing behavior.
- Pass configured thinking levels through to `pi-ai` via the summarizer `complete()` call options.
- Expose the setting through `/pruner status`, `/pruner thinking`, `/pruner settings`, and `/pruner model <id>:<thinking>` shorthand.
- Document supported thinking levels and provider behavior caveats in the README.

## Details
This adds a new global config field:

```json
{
  "summarizerThinking": "default"
}
```

Supported values are:

```text
default, off, minimal, low, medium, high, xhigh
```

`default` intentionally sends no explicit thinking option, matching previous behavior. Non-default values are forwarded to `pi-ai` as summarizer call options so provider adapters can translate them into the provider-specific payload.

Users can configure it directly:

```text
/pruner thinking low
```

or set model and thinking together:

```text
/pruner model nahcrof/deepseek-v4-pro-precision:high
```

The settings overlay now includes a fourth item, **Summarizer thinking**, and `/pruner status` reports the current level.

## Validation
- `npx tsc --noEmit --moduleResolution bundler --module esnext --target es2022 --skipLibCheck index.ts src/*.ts`
- `npm run check`
- `git diff --check`
- Live Pi smoke test with `summarizerThinking: "minimal"` verified summary/index entries and `context_tree_query` recovery.
- Payload-level verification confirmed `nahcrof/deepseek-v4-pro-precision:high` reaches the provider payload as `reasoning_effort: "high"`.
- Headless Pi command test verified `/pruner model nahcrof/deepseek-v4-pro-precision:high` persists:

```json
{
  "summarizerModel": "nahcrof/deepseek-v4-pro-precision",
  "summarizerThinking": "high"
}
```

- Invalid shorthand suffix test verified `/pruner model ...:nope` warns and leaves config unchanged.

