### PR TITLE
Add token accounting utilities for pruning decisions

### DIFF
--- a/.agents/plans/016-token-accounting-utilities.md
+++ b/.agents/plans/016-token-accounting-utilities.md
@@ -1,0 +1,212 @@
+---
+name: 016-token-accounting-utilities
+description: Add token accounting infrastructure (estimator + rawTokenCount / summaryTokenCount / tokensSaved / savingsRatio) so future pruning policy decisions can be token-aware. Char-based behavior is preserved; this PR is pure instrumentation. Closes issue #4 (parent #3).
+steps:
+  - phase: discovery
+    steps:
+      - "- [x] step 1: re-read issue #4 acceptance criteria and #3 rollout principle to confirm scope is instrumentation-only"
+      - "- [x] step 2: catalogue every site that currently uses rawCharCount / summaryCharCount (frontier, flush result, /pruner now notification, status text)"
+      - "- [x] step 3: decide on a fallback estimator that is deterministic, dependency-free, and matches widely-used heuristics"
+      - "- [x] step 4: decide where token counts plug into PruneFrontier and FlushResult without breaking older persisted entries"
+  - phase: implementation
+    steps:
+      - "- [x] step 1: add `src/tokens.ts` with `estimateTokens(text)` fallback + `countTokens(text, model?)` wrapper"
+      - "- [x] step 2: extend `PruneFrontier` and `FlushResult` types with optional rawTokenCount / summaryTokenCount / tokensSaved / savingsRatio fields"
+      - "- [x] step 3: compute the new metrics inside `flushPending` and persist them on the frontier"
+      - "- [x] step 4: hydrate the new fields in `PruneFrontierTracker.fromJSON` so older sessions load cleanly with safe defaults"
+      - "- [x] step 5: surface token metrics in the /pruner now notification (additive, char metrics unchanged)"
+      - "- [x] step 6: add tests for fallback estimation (small/medium/empty) and savings calculations (positive, zero, negative)"
+      - "- [x] step 7: add a `test` script to package.json so the tests can be run via `npm test`"
+  - phase: validation
+    steps:
+      - "- [x] step 1: run `npm test` locally and confirm all assertions pass"
+      - "- [x] step 2: review the diff for behavior parity (no pruning trigger / acceptance changes)"
+      - "- [x] step 3: commit on the feature branch and push for PR review"
+---
+
+# 016-token-accounting-utilities
+
+## Context
+
+Issue #4 is the first sub-issue of the broader token-/cache-aware pruning policy
+tracked in #3. The roadmap is intentionally staged:
+
+> 1. instrumentation and token accounting
+> 2. token-aware skip/accept thresholds
+> 3. context-pressure triggering
+> 4. telemetry/stats
+> 5. cache-aware ROI mode
+
+This plan covers **only step 1**. There must be no behavioral change to when
+pruning triggers or whether a summary is accepted/skipped. We are purely adding
+the numbers that later PRs will consume.
+
+## Acceptance criteria (from #4)
+
+- Existing behavior is unchanged.
+- Token metrics are available to later PRs.
+- If provider/model token counting is unavailable, the fallback estimator is deterministic.
+- Tests cover small, medium, and empty text cases.
+
+## Where char metrics live today
+
+`flushPending` (in `index.ts`) and `PruneFrontier` (in `src/types.ts`) already
+track:
+
+- `rawCharCount` — sum of `tc.resultText.length` across the pending batches
+- `summaryCharCount` — `result.summaryText.length`
+
+These two numbers also drive:
+
+- the `shouldSkipOversized` decision (must keep this char-based for now per #4),
+- the `/pruner now` notification text (in `src/commands.ts`),
+- the oversized-skip warning (in `index.ts`).
+
+We will **not** change the skip decision. We will only add parallel token
+fields next to the existing char fields.
+
+## Design
+
+### `src/tokens.ts`
+
+A small, dependency-free module:
+
+```ts
+/**
+ * Deterministic fallback token estimator. Uses the widely-cited
+ * "1 token ≈ 4 chars of English/code" heuristic and rounds up so empty
+ * strings yield 0, very short strings yield 1, etc.
+ *
+ * This is intentionally simple. Real provider token counts are preferred
+ * when available via `countTokens(text, model)`.
+ */
+export function estimateTokens(text: string): number;
+
+/**
+ * Token count for `text`, using the model's tokenizer when one is available
+ * on the supplied model object. Falls back to `estimateTokens` deterministically
+ * when no tokenizer is exposed or it throws. This wrapper exists so future
+ * pruning policy can call a single function regardless of provider support.
+ */
+export function countTokens(text: string, model?: unknown): number;
+
+/**
+ * Compute tokens-saved and savings-ratio from raw + summary token counts.
+ * `savingsRatio` is in [-Infinity, 1]: positive ratios mean we saved tokens,
+ * 0 means no change, negative means the summary is bigger than the raw text.
+ * Returns `{ tokensSaved: 0, savingsRatio: 0 }` for empty raw input so callers
+ * never have to guard against divide-by-zero.
+ */
+export function computeSavings(rawTokens: number, summaryTokens: number): {
+  tokensSaved: number;
+  savingsRatio: number;
+};
+```
+
+Notes:
+
+- The fallback uses `Math.ceil(text.length / 4)` so it is deterministic and
+  monotonic. Tests pin the exact outputs for representative inputs.
+- `countTokens` is duck-typed against any model that exposes `countTokens` /
+  `tokenize` so future provider integrations can light it up without changing
+  callers. Errors and missing tokenizers always fall through to `estimateTokens`.
+
+### Type extensions (`src/types.ts`)
+
+Add optional fields to keep older persisted snapshots loadable:
+
+```ts
+export interface PruneFrontier {
+  // ...existing fields...
+  rawTokenCount?: number;
+  summaryTokenCount?: number;
+  tokensSaved?: number;
+  savingsRatio?: number;
+}
+```
+
+`PruneFrontierTracker.fromJSON` will default missing values to `0` so older
+session entries do not crash the tracker.
+
+### `flushPending` wiring (`index.ts`)
+
+Right after computing `rawCharCount`:
+
+```ts
+const rawTokenCount = batches.reduce(
+  (sum, batch) =>
+    sum + batch.toolCalls.reduce(
+      (batchSum, tc) => batchSum + estimateTokens(tc.resultText),
+      0,
+    ),
+  0,
+);
+```
+
+Right after the summarizer returns (and we know `summaryCharCount`):
+
+```ts
+const summaryTokenCount = estimateTokens(result.summaryText);
+const { tokensSaved, savingsRatio } = computeSavings(rawTokenCount, summaryTokenCount);
+```
+
+These four numbers are then included in the `buildFrontier(...)` payload and in
+the typed `FlushResult` so they ride along with the existing char metrics.
+
+### Notification
+
+`/pruner now` already prints raw vs summary char counts. We append a token line
+after the existing char line so existing tests / scripts that parse the message
+still see the char numbers where they are today:
+
+```
+pruner: pruned 6 tool calls from 2 batches — summary 1.2k chars vs 4.8k raw chars (≈ 312 vs 1284 tokens, saved 972 / 75.7%)
+```
+
+The message stays a single line so the existing `ctx.ui.notify` path is
+unchanged structurally.
+
+### Testing
+
+- New file: `src/tokens.test.ts`
+- Runner: Node's built-in `node:test` with `node --experimental-strip-types`,
+  which is available on the Node 22+ that this repo already targets locally.
+  No new runtime deps are added.
+- Cases:
+  - `estimateTokens("")` → `0`
+  - `estimateTokens("hi")` → `1`
+  - `estimateTokens("the quick brown fox")` → `5` (length 19, ceil(19/4) = 5)
+  - `estimateTokens(<512-char block>)` → `128`
+  - `countTokens("abc")` falls back to estimator with no model
+  - `countTokens("abc", { countTokens: () => 7 })` returns 7
+  - `countTokens("abc", { countTokens: () => { throw new Error() } })` falls back
+  - `computeSavings(0, 0)` → `{ tokensSaved: 0, savingsRatio: 0 }`
+  - `computeSavings(100, 25)` → `{ tokensSaved: 75, savingsRatio: 0.75 }`
+  - `computeSavings(100, 150)` → `{ tokensSaved: -50, savingsRatio: -0.5 }`
+
+## Phase 1 — Discovery
+- [x] step 1: re-read issue #4 acceptance criteria and #3 rollout principle to confirm scope is instrumentation-only
+- [x] step 2: catalogue every site that currently uses rawCharCount / summaryCharCount (frontier in `src/types.ts`, `flushPending` in `index.ts`, `/pruner now` notification in `src/commands.ts`, oversized-skip warning in `index.ts`)
+- [x] step 3: decide on a fallback estimator (Math.ceil(length / 4), deterministic, no deps)
+- [x] step 4: decide where token counts plug in (PruneFrontier + FlushResult, both with optional fields for forward/back compat)
+
+## Phase 2 — Implementation
+- [x] step 1: add `src/tokens.ts` with `estimateTokens`, `countTokens`, and `computeSavings`
+- [x] step 2: extend `PruneFrontier` and `FlushResult` with optional rawTokenCount / summaryTokenCount / tokensSaved / savingsRatio fields
+- [x] step 3: compute the new metrics inside `flushPending` and persist them on the frontier
+- [x] step 4: hydrate the new fields in `PruneFrontierTracker.fromJSON` with safe defaults
+- [x] step 5: surface token metrics in the `/pruner now` notification (additive only)
+- [x] step 6: add `src/tokens.test.ts` covering empty/small/medium estimation and savings positive/zero/negative
+- [x] step 7: add a `test` script in `package.json` that runs the test file via Node's built-in test runner
+
+## Phase 3 — Validation
+- [x] step 1: run `npm test` locally and confirm all assertions pass
+- [x] step 2: re-read the diff and confirm no pruning trigger / accept-skip behavior moved
+- [x] step 3: commit on `issue-4-token-accounting` and push for PR review
+
+## Out of scope (per #4 non-goals)
+
+- Changing when pruning triggers (no new thresholds, no context-pressure logic).
+- Changing the prune accept/skip rule (still char-based).
+- Cache-aware policy.
+- Persisting token-counter telemetry beyond what naturally lands on the frontier.

--- a/.agents/plans/017-pr-review-followups-token-accounting.md
+++ b/.agents/plans/017-pr-review-followups-token-accounting.md
@@ -1,0 +1,52 @@
+---
+name: 017-pr-review-followups-token-accounting
+description: Address PR #9 review feedback for issue #4 by fixing wording, fallback accounting consistency, async-tokenizer hardening, and Node 20-compatible test execution.
+steps:
+  - phase: discovery
+    steps:
+      - "- [x] step 1: fetch PR #9 review comments and classify each as blocker / should-fix / optional"
+      - "- [x] step 2: verify the Node 20 compatibility concern against the repo's release workflow"
+      - "- [x] step 3: decide the smallest safe implementation for all four comments"
+  - phase: implementation
+    steps:
+      - "- [x] step 1: harden `src/tokens.ts` against async/thenable tokenizer results without making the public API async"
+      - "- [x] step 2: improve `formatTokenMetrics()` wording for negative/zero savings"
+      - "- [x] step 3: change fallback raw-token accounting to round once on aggregated raw text rather than per-tool-call"
+      - "- [x] step 4: switch the test runner setup to something that works on both Node 20 and Node 22"
+      - "- [x] step 5: update/add tests for the new token helper behavior and wording-sensitive logic where appropriate"
+  - phase: validation
+    steps:
+      - "- [x] step 1: run `npm test` on the current Node version"
+      - "- [x] step 2: run `npm test` on Node 20 (via nvm/npx) to confirm workflow compatibility"
+      - "- [x] step 3: review the diff to confirm issue #4 behavior remains instrumentation-only"
+      - "- [x] step 4: commit, push, and update PR #9"
+---
+
+# 017-pr-review-followups-token-accounting
+
+## Review summary
+
+PR #9 received four Copilot comments. After inspection:
+
+1. **Async tokenizer assumption** — legit but future-facing. We can harden the helper cheaply by detecting thenables and falling back deterministically.
+2. **`saved -50` wording** — legit user-facing bug. Must fix.
+3. **Per-tool fallback rounding bias** — legit instrumentation-quality issue. Fix by aggregating raw text before fallback counting.
+4. **Node 20-incompatible test script** — legit and important. The release workflow uses Node 20, so `npm test` / `npm run check` should work there too.
+
+## Chosen implementation
+
+- Keep `countTokens()` synchronous, but detect Promise-like return values and attach a no-op rejection handler before falling back.
+- Make `formatTokenMetrics()` say one of:
+  - `saved N (...)`
+  - `no token change (...)`
+  - `grew by N (...)`
+- Add a helper to count a collection of text blocks in aggregate so the fallback estimator rounds once.
+- Replace the `--experimental-strip-types` test script with a Node-20-compatible TypeScript runner (`tsx`).
+- Validate on both Node 22 and Node 20 before pushing.
+
+## Validation notes
+
+- `npm test` passes on Node `v22.17.0`.
+- `npm run check` passes on Node `v22.17.0`.
+- `npm test` passes on Node `v20.20.0` via `nvm use 20.20.0`.
+- The follow-up keeps issue #4 instrumentation-only: prune triggers and char-based oversized skip behavior are unchanged.

--- a/index.ts
+++ b/index.ts
@@ -17,6 +17,7 @@ import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { loadConfig } from "./src/config.js";
 import { captureBatch } from "./src/batch-capture.js";
 import { summarizeBatches } from "./src/summarizer.js";
+import { countTokens, computeSavings, formatTokenMetrics, type TokenAccountingMetrics } from "./src/tokens.js";
 import { ToolCallIndexer } from "./src/indexer.js";
 import { pruneMessages } from "./src/pruner.js";
 import { annotateWithUnprunedCount, countUnprunedToolCalls } from "./src/reminder.js";
@@ -57,7 +58,7 @@ export default function (pi: ExtensionAPI) {
   let isFlushing = false;
 
   type FlushResult =
-    | { ok: true; reason: "flushed" | "skipped-oversized"; batchCount: number; toolCallCount: number; rawCharCount: number; summaryCharCount: number }
+    | ({ ok: true; reason: "flushed" | "skipped-oversized"; batchCount: number; toolCallCount: number; rawCharCount: number; summaryCharCount: number } & TokenAccountingMetrics)
     | { ok: false; reason: "empty" | "already-flushing" | "summarizer-failed" | "stale-context" | "failed"; error?: string };
 
   type SessionAppender = {
@@ -159,8 +160,16 @@ export default function (pi: ExtensionAPI) {
         (sum, batch) => sum + batch.toolCalls.reduce((batchSum, tc) => batchSum + tc.resultText.length, 0),
         0
       );
+      const rawTokenCount = batches.reduce(
+        (sum, batch) => sum + batch.toolCalls.reduce((batchSum, tc) => batchSum + countTokens(tc.resultText), 0),
+        0
+      );
 
-      const buildFrontier = (outcome: PruneFrontier["outcome"], summaryCharCount: number): PruneFrontier => {
+      const buildFrontier = (
+        outcome: PruneFrontier["outcome"],
+        summaryCharCount: number,
+        tokenMetrics: TokenAccountingMetrics
+      ): PruneFrontier => {
         const lastBatch = batches[batches.length - 1];
         const lastToolCall = lastBatch.toolCalls[lastBatch.toolCalls.length - 1];
         return {
@@ -172,6 +181,10 @@ export default function (pi: ExtensionAPI) {
           attemptedToolCallCount: toolCallCount,
           rawCharCount,
           summaryCharCount,
+          rawTokenCount: tokenMetrics.rawTokenCount,
+          summaryTokenCount: tokenMetrics.summaryTokenCount,
+          tokensSaved: tokenMetrics.tokensSaved,
+          savingsRatio: tokenMetrics.savingsRatio,
           outcome,
         };
       };
@@ -186,10 +199,12 @@ export default function (pi: ExtensionAPI) {
       }
 
       const summaryCharCount = result.summaryText.length;
+      const tokenMetrics = computeSavings(rawTokenCount, countTokens(result.summaryText));
       const shouldSkipOversized = summaryCharCount > rawCharCount;
       const frontierSnapshot = buildFrontier(
         shouldSkipOversized ? "skipped-oversized" : "summarized",
-        summaryCharCount
+        summaryCharCount,
+        tokenMetrics
       );
       const details = {
         toolCallIds: batches.flatMap((b) => b.toolCalls.map((tc) => tc.toolCallId)),
@@ -257,7 +272,7 @@ export default function (pi: ExtensionAPI) {
       if (shouldSkipOversized) {
         safeNotify(
           ctx,
-          `pruner: skipped pruning ${toolCallCount} tool call${toolCallCount === 1 ? "" : "s"} — summary was ${summaryCharCount} chars vs ${rawCharCount} raw chars; frontier advanced past this range`,
+          `pruner: skipped pruning ${toolCallCount} tool call${toolCallCount === 1 ? "" : "s"} — summary was ${summaryCharCount} chars vs ${rawCharCount} raw chars (${formatTokenMetrics(tokenMetrics)}); frontier advanced past this range`,
           "warning"
         );
       }
@@ -268,6 +283,10 @@ export default function (pi: ExtensionAPI) {
         toolCallCount,
         rawCharCount,
         summaryCharCount,
+        rawTokenCount: tokenMetrics.rawTokenCount,
+        summaryTokenCount: tokenMetrics.summaryTokenCount,
+        tokensSaved: tokenMetrics.tokensSaved,
+        savingsRatio: tokenMetrics.savingsRatio,
       };
     } catch (err) {
       restoreBatches(batches);

--- a/index.ts
+++ b/index.ts
@@ -17,7 +17,7 @@ import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { loadConfig } from "./src/config.js";
 import { captureBatch } from "./src/batch-capture.js";
 import { summarizeBatches } from "./src/summarizer.js";
-import { countTokens, computeSavings, formatTokenMetrics, type TokenAccountingMetrics } from "./src/tokens.js";
+import { countTextBlocksTokens, countTokens, computeSavings, formatTokenMetrics, type TokenAccountingMetrics } from "./src/tokens.js";
 import { ToolCallIndexer } from "./src/indexer.js";
 import { pruneMessages } from "./src/pruner.js";
 import { annotateWithUnprunedCount, countUnprunedToolCalls } from "./src/reminder.js";
@@ -156,14 +156,9 @@ export default function (pi: ExtensionAPI) {
     try {
       safeSetStatus(ctx, "prune: summarizing…");
 
-      const rawCharCount = batches.reduce(
-        (sum, batch) => sum + batch.toolCalls.reduce((batchSum, tc) => batchSum + tc.resultText.length, 0),
-        0
-      );
-      const rawTokenCount = batches.reduce(
-        (sum, batch) => sum + batch.toolCalls.reduce((batchSum, tc) => batchSum + countTokens(tc.resultText), 0),
-        0
-      );
+      const rawToolResults = batches.flatMap((batch) => batch.toolCalls.map((tc) => tc.resultText));
+      const rawCharCount = rawToolResults.reduce((sum, resultText) => sum + resultText.length, 0);
+      const rawTokenCount = countTextBlocksTokens(rawToolResults);
 
       const buildFrontier = (
         outcome: PruneFrontier["outcome"],

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "echo 'nothing to build'",
     "check": "npm test",
-    "test": "node --test --experimental-strip-types ./src/tokens.test.ts"
+    "test": "tsx --test ./src/tokens.test.ts"
   },
   "keywords": [
     "pi-package"
@@ -30,6 +30,9 @@
     "prompts": [
       "./prompts"
     ]
+  },
+  "devDependencies": {
+    "tsx": "^4.20.6"
   },
   "peerDependencies": {
     "@mariozechner/pi-coding-agent": "*",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "build": "echo 'nothing to build'",
-    "check": "echo 'nothing to check'"
+    "check": "npm test",
+    "test": "node --test --experimental-strip-types ./src/tokens.test.ts"
   },
   "keywords": [
     "pi-package"

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -8,6 +8,8 @@ import {
 import type { ExtensionAPI, ExtensionCommandContext } from "@mariozechner/pi-coding-agent";
 import { saveConfig } from "./config.js";
 import { formatTokens, formatCost } from "./stats.js";
+import type { TokenAccountingMetrics } from "./tokens.js";
+import { formatTokenMetrics } from "./tokens.js";
 import { Container, Text, SettingsList, type SettingItem } from "@mariozechner/pi-tui";
 import { DynamicBorder, getSettingsListTheme } from "@mariozechner/pi-coding-agent";
 import { buildPruneTree, TreeBrowser } from "./tree-browser.js";
@@ -182,7 +184,7 @@ export function registerCommands(
   pi: ExtensionAPI,
   currentConfig: { value: ContextPruneConfig },
   flushPending: (ctx: ExtensionCommandContext) => Promise<
-    | { ok: true; reason: "flushed" | "skipped-oversized"; batchCount: number; toolCallCount: number; rawCharCount: number; summaryCharCount: number }
+    | ({ ok: true; reason: "flushed" | "skipped-oversized"; batchCount: number; toolCallCount: number; rawCharCount: number; summaryCharCount: number } & TokenAccountingMetrics)
     | { ok: false; reason: string; error?: string }
   >,
   syncToolActivation: () => void,
@@ -506,14 +508,14 @@ export function registerCommands(
 
           if (result.reason === "skipped-oversized") {
             ctx.ui.notify(
-              `pruner: skipped pruning ${result.toolCallCount} tool call${result.toolCallCount === 1 ? "" : "s"} — summary was ${result.summaryCharCount} chars vs ${result.rawCharCount} raw chars; frontier advanced past this range`,
+              `pruner: skipped pruning ${result.toolCallCount} tool call${result.toolCallCount === 1 ? "" : "s"} — summary was ${result.summaryCharCount} chars vs ${result.rawCharCount} raw chars (${formatTokenMetrics(result)}); frontier advanced past this range`,
               "warning"
             );
             break;
           }
 
           ctx.ui.notify(
-            `pruner: pruned ${result.toolCallCount} tool call${result.toolCallCount === 1 ? "" : "s"} from ${result.batchCount} batch${result.batchCount === 1 ? "" : "es"} — summary ${result.summaryCharCount} chars vs ${result.rawCharCount} raw chars`,
+            `pruner: pruned ${result.toolCallCount} tool call${result.toolCallCount === 1 ? "" : "s"} from ${result.batchCount} batch${result.batchCount === 1 ? "" : "es"} — summary ${result.summaryCharCount} chars vs ${result.rawCharCount} raw chars (${formatTokenMetrics(result)})`,
             "info"
           );
           break;

--- a/src/context-prune-tool.ts
+++ b/src/context-prune-tool.ts
@@ -10,6 +10,8 @@
 import { Type } from "@sinclair/typebox";
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
 import { CONTEXT_PRUNE_TOOL_NAME } from "./types.js";
+import type { TokenAccountingMetrics } from "./tokens.js";
+import { formatTokenMetrics } from "./tokens.js";
 
 /**
  * Registers the context_prune tool with Pi.
@@ -19,8 +21,8 @@ import { CONTEXT_PRUNE_TOOL_NAME } from "./types.js";
  * @param flushPending  Shared flush function that summarizes + indexes pending batches
  */
 type FlushResult =
-  | { ok: true; reason: "flushed"; batchCount: number; toolCallCount: number; rawCharCount: number; summaryCharCount: number }
-  | { ok: true; reason: "skipped-oversized"; batchCount: number; toolCallCount: number; rawCharCount: number; summaryCharCount: number }
+  | ({ ok: true; reason: "flushed"; batchCount: number; toolCallCount: number; rawCharCount: number; summaryCharCount: number } & TokenAccountingMetrics)
+  | ({ ok: true; reason: "skipped-oversized"; batchCount: number; toolCallCount: number; rawCharCount: number; summaryCharCount: number } & TokenAccountingMetrics)
   | { ok: false; reason: string; error?: string };
 
 export function registerContextPruneTool(
@@ -63,7 +65,7 @@ export function registerContextPruneTool(
             content: [
               {
                 type: "text",
-                text: `Context prune skipped ${result.toolCallCount} tool call${result.toolCallCount === 1 ? "" : "s"}: the summary was ${result.summaryCharCount} chars while the raw tool results were ${result.rawCharCount} chars. The original tool results were kept, and the prune frontier advanced so the next prune starts after this range.`,
+                text: `Context prune skipped ${result.toolCallCount} tool call${result.toolCallCount === 1 ? "" : "s"}: the summary was ${result.summaryCharCount} chars while the raw tool results were ${result.rawCharCount} chars (${formatTokenMetrics(result)}). The original tool results were kept, and the prune frontier advanced so the next prune starts after this range.`,
               },
             ],
             details: result,
@@ -74,7 +76,7 @@ export function registerContextPruneTool(
           content: [
             {
               type: "text",
-              text: `Context prune completed. Summarized ${result.toolCallCount} tool call${result.toolCallCount === 1 ? "" : "s"} from ${result.batchCount} batch${result.batchCount === 1 ? "" : "es"}. Summary size: ${result.summaryCharCount} chars vs ${result.rawCharCount} raw chars. Use context_tree_query with the toolCallIds from the summary to retrieve full outputs if needed.`,
+              text: `Context prune completed. Summarized ${result.toolCallCount} tool call${result.toolCallCount === 1 ? "" : "s"} from ${result.batchCount} batch${result.batchCount === 1 ? "" : "es"}. Summary size: ${result.summaryCharCount} chars vs ${result.rawCharCount} raw chars (${formatTokenMetrics(result)}). Use context_tree_query with the toolCallIds from the summary to retrieve full outputs if needed.`,
             },
           ],
           details: result,

--- a/src/frontier.ts
+++ b/src/frontier.ts
@@ -31,6 +31,10 @@ export class PruneFrontierTracker {
       attemptedToolCallCount: data.attemptedToolCallCount ?? 0,
       rawCharCount: data.rawCharCount ?? 0,
       summaryCharCount: data.summaryCharCount ?? 0,
+      rawTokenCount: data.rawTokenCount ?? 0,
+      summaryTokenCount: data.summaryTokenCount ?? 0,
+      tokensSaved: data.tokensSaved ?? 0,
+      savingsRatio: data.savingsRatio ?? 0,
       outcome: data.outcome ?? "summarized",
     };
   }

--- a/src/tokens.test.ts
+++ b/src/tokens.test.ts
@@ -1,6 +1,12 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { computeSavings, countTokens, estimateTokens } from "./tokens.ts";
+import {
+  computeSavings,
+  countTextBlocksTokens,
+  countTokens,
+  estimateTokens,
+  formatTokenMetrics,
+} from "./tokens.ts";
 
 test("estimateTokens returns 0 for empty text", () => {
   assert.equal(estimateTokens(""), 0);
@@ -37,8 +43,27 @@ test("countTokens falls back when model.countTokens throws", () => {
   );
 });
 
+test("countTokens falls back when model.countTokens returns a promise", async () => {
+  assert.equal(countTokens("abc", { countTokens: () => Promise.resolve(7) }), 1);
+  await Promise.resolve();
+});
+
+test("countTokens suppresses async tokenizer rejections and falls back", async () => {
+  assert.equal(
+    countTokens("abc", {
+      countTokens: () => Promise.reject(new Error("boom")),
+    }),
+    1,
+  );
+  await Promise.resolve();
+});
+
 test("countTokens uses model.tokenize array length when available", () => {
   assert.equal(countTokens("abc", { tokenize: () => [1, 2, 3, 4] }), 4);
+});
+
+test("countTextBlocksTokens rounds once on aggregated fallback text", () => {
+  assert.equal(countTextBlocksTokens(["a", "a", "a", "a", "a"]), 2);
 });
 
 test("computeSavings returns zero ratio for empty raw input", () => {
@@ -66,4 +91,25 @@ test("computeSavings returns negative savings when summaries are larger", () => 
     tokensSaved: -50,
     savingsRatio: -0.5,
   });
+});
+
+test("formatTokenMetrics uses saved wording for positive savings", () => {
+  assert.equal(
+    formatTokenMetrics(computeSavings(100, 25)),
+    "≈ 25 summary vs 100 raw tokens, saved 75 (75.0%)",
+  );
+});
+
+test("formatTokenMetrics uses no-change wording for flat savings", () => {
+  assert.equal(
+    formatTokenMetrics(computeSavings(100, 100)),
+    "≈ 100 summary vs 100 raw tokens, no token change (0.0%)",
+  );
+});
+
+test("formatTokenMetrics uses grew-by wording for negative savings", () => {
+  assert.equal(
+    formatTokenMetrics(computeSavings(100, 150)),
+    "≈ 150 summary vs 100 raw tokens, grew by 50 (-50.0%)",
+  );
 });

--- a/src/tokens.test.ts
+++ b/src/tokens.test.ts
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { computeSavings, countTokens, estimateTokens } from "./tokens.ts";
+
+test("estimateTokens returns 0 for empty text", () => {
+  assert.equal(estimateTokens(""), 0);
+});
+
+test("estimateTokens rounds short text up to one token", () => {
+  assert.equal(estimateTokens("hi"), 1);
+});
+
+test("estimateTokens is deterministic for medium text", () => {
+  assert.equal(estimateTokens("the quick brown fox"), 5);
+});
+
+test("estimateTokens scales linearly for larger blocks", () => {
+  assert.equal(estimateTokens("a".repeat(512)), 128);
+});
+
+test("countTokens falls back to the estimator when no model is provided", () => {
+  assert.equal(countTokens("abc"), 1);
+});
+
+test("countTokens uses model.countTokens when available", () => {
+  assert.equal(countTokens("abc", { countTokens: () => 7 }), 7);
+});
+
+test("countTokens falls back when model.countTokens throws", () => {
+  assert.equal(
+    countTokens("abc", {
+      countTokens: () => {
+        throw new Error("boom");
+      },
+    }),
+    1,
+  );
+});
+
+test("countTokens uses model.tokenize array length when available", () => {
+  assert.equal(countTokens("abc", { tokenize: () => [1, 2, 3, 4] }), 4);
+});
+
+test("computeSavings returns zero ratio for empty raw input", () => {
+  assert.deepEqual(computeSavings(0, 0), {
+    rawTokenCount: 0,
+    summaryTokenCount: 0,
+    tokensSaved: 0,
+    savingsRatio: 0,
+  });
+});
+
+test("computeSavings returns positive savings for smaller summaries", () => {
+  assert.deepEqual(computeSavings(100, 25), {
+    rawTokenCount: 100,
+    summaryTokenCount: 25,
+    tokensSaved: 75,
+    savingsRatio: 0.75,
+  });
+});
+
+test("computeSavings returns negative savings when summaries are larger", () => {
+  assert.deepEqual(computeSavings(100, 150), {
+    rawTokenCount: 100,
+    summaryTokenCount: 150,
+    tokensSaved: -50,
+    savingsRatio: -0.5,
+  });
+});

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -1,0 +1,85 @@
+export interface TokenAccountingMetrics {
+  rawTokenCount: number;
+  summaryTokenCount: number;
+  tokensSaved: number;
+  savingsRatio: number;
+}
+
+const FALLBACK_CHARS_PER_TOKEN = 4;
+
+function normalizeTokenCount(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return Math.max(0, Math.round(value));
+  }
+
+  if (Array.isArray(value)) {
+    return value.length;
+  }
+
+  if (value && typeof value === "object") {
+    const candidate = value as Record<string, unknown>;
+    for (const key of ["totalTokens", "tokenCount", "count", "tokens"]) {
+      const normalized = normalizeTokenCount(candidate[key]);
+      if (normalized !== null) return normalized;
+    }
+  }
+
+  return null;
+}
+
+/** Deterministic fallback token estimator used when no model tokenizer is available. */
+export function estimateTokens(text: string): number {
+  if (!text) return 0;
+  return Math.ceil(text.length / FALLBACK_CHARS_PER_TOKEN);
+}
+
+/**
+ * Count tokens with a model-provided tokenizer when possible.
+ * Falls back to `estimateTokens()` if the model exposes no tokenizer,
+ * returns an unsupported shape, or throws while counting.
+ */
+export function countTokens(text: string, model?: unknown): number {
+  if (!text) return 0;
+  if (!model || typeof model !== "object") return estimateTokens(text);
+
+  const candidate = model as {
+    countTokens?: (input: string) => unknown;
+    tokenize?: (input: string) => unknown;
+  };
+
+  try {
+    if (typeof candidate.countTokens === "function") {
+      const normalized = normalizeTokenCount(candidate.countTokens(text));
+      if (normalized !== null) return normalized;
+    }
+
+    if (typeof candidate.tokenize === "function") {
+      const normalized = normalizeTokenCount(candidate.tokenize(text));
+      if (normalized !== null) return normalized;
+    }
+  } catch {
+    // Ignore tokenizer failures and fall back to the deterministic estimator.
+  }
+
+  return estimateTokens(text);
+}
+
+/** Compute token savings for raw text vs its summary. */
+export function computeSavings(rawTokenCount: number, summaryTokenCount: number): TokenAccountingMetrics {
+  const tokensSaved = rawTokenCount - summaryTokenCount;
+  const savingsRatio = rawTokenCount <= 0 ? 0 : tokensSaved / rawTokenCount;
+  return {
+    rawTokenCount,
+    summaryTokenCount,
+    tokensSaved,
+    savingsRatio,
+  };
+}
+
+export function formatSavingsRatio(savingsRatio: number): string {
+  return `${(savingsRatio * 100).toFixed(1)}%`;
+}
+
+export function formatTokenMetrics(metrics: TokenAccountingMetrics): string {
+  return `≈ ${metrics.summaryTokenCount} summary vs ${metrics.rawTokenCount} raw tokens, saved ${metrics.tokensSaved} (${formatSavingsRatio(metrics.savingsRatio)})`;
+}

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -7,7 +7,28 @@ export interface TokenAccountingMetrics {
 
 const FALLBACK_CHARS_PER_TOKEN = 4;
 
+type TokenizerResult = PromiseLike<unknown> & {
+  catch?: (onRejected: (reason: unknown) => unknown) => unknown;
+};
+
+function isThenable(value: unknown): value is TokenizerResult {
+  return !!value && (typeof value === "object" || typeof value === "function") && typeof (value as { then?: unknown }).then === "function";
+}
+
+function discardThenable(value: TokenizerResult): null {
+  if (typeof value.catch === "function") {
+    void value.catch(() => undefined);
+  } else {
+    void value.then(undefined, () => undefined);
+  }
+  return null;
+}
+
 function normalizeTokenCount(value: unknown): number | null {
+  if (isThenable(value)) {
+    return discardThenable(value);
+  }
+
   if (typeof value === "number" && Number.isFinite(value)) {
     return Math.max(0, Math.round(value));
   }
@@ -64,6 +85,12 @@ export function countTokens(text: string, model?: unknown): number {
   return estimateTokens(text);
 }
 
+/** Count tokens across multiple text blocks, rounding once on the aggregate text. */
+export function countTextBlocksTokens(texts: string[], model?: unknown): number {
+  if (texts.length === 0) return 0;
+  return countTokens(texts.join(""), model);
+}
+
 /** Compute token savings for raw text vs its summary. */
 export function computeSavings(rawTokenCount: number, summaryTokenCount: number): TokenAccountingMetrics {
   const tokensSaved = rawTokenCount - summaryTokenCount;
@@ -81,5 +108,13 @@ export function formatSavingsRatio(savingsRatio: number): string {
 }
 
 export function formatTokenMetrics(metrics: TokenAccountingMetrics): string {
-  return `≈ ${metrics.summaryTokenCount} summary vs ${metrics.rawTokenCount} raw tokens, saved ${metrics.tokensSaved} (${formatSavingsRatio(metrics.savingsRatio)})`;
+  const counts = `≈ ${metrics.summaryTokenCount} summary vs ${metrics.rawTokenCount} raw tokens`;
+  const ratio = formatSavingsRatio(metrics.savingsRatio);
+  if (metrics.tokensSaved > 0) {
+    return `${counts}, saved ${metrics.tokensSaved} (${ratio})`;
+  }
+  if (metrics.tokensSaved < 0) {
+    return `${counts}, grew by ${Math.abs(metrics.tokensSaved)} (${ratio})`;
+  }
+  return `${counts}, no token change (${ratio})`;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -262,6 +262,14 @@ export interface PruneFrontier {
   rawCharCount: number;
   /** Character count of the rendered summary text that was produced */
   summaryCharCount: number;
+  /** Estimated / counted tokens for the raw tool-result text that was eligible for pruning */
+  rawTokenCount?: number;
+  /** Estimated / counted tokens for the rendered summary text that was produced */
+  summaryTokenCount?: number;
+  /** Positive when the summary saved tokens; negative when it grew */
+  tokensSaved?: number;
+  /** Fraction of raw tokens saved (0 for empty raw input; negative when the summary grew) */
+  savingsRatio?: number;
   /** Whether the attempt actually pruned or was skipped for being oversized */
   outcome: PruneFrontierOutcome;
 }


### PR DESCRIPTION
## Summary
- add token accounting helpers with deterministic fallback estimation and savings calculations
- thread raw/summary token metrics through prune flush results, frontier persistence, and user-facing prune responses
- add focused tests for empty/small/medium fallback estimation and positive/zero/negative savings cases

## Notes
- prune trigger behavior is unchanged
- prune accept/skip behavior remains char-based in this PR
- live token metrics currently use the deterministic fallback estimator unless a future PR threads a model tokenizer through runtime counting

## Testing
- npm test
- npm run check

Closes #4