### PR TITLE
Add configurable minimum raw-size guard before prune summaries

### DIFF
--- a/.agents/plans/031-min-raw-threshold-setting-and-skip-flow.md
+++ b/.agents/plans/031-min-raw-threshold-setting-and-skip-flow.md
@@ -1,0 +1,47 @@
+---
+name: 031-min-raw-threshold-setting-and-skip-flow
+description: Add a configurable minimum raw character threshold for pruning batches, using presets Disabled (0), Default (700), and Large (1000), and skip undersized batches before summarization while preserving existing oversized-summary behavior.
+steps:
+  - phase: implementation
+    steps:
+      - "- [x] step 1: add minRawCharsToPrune to shared types and default config with values persisted through settings.json"
+      - "- [x] step 2: wire the setting into /pruner settings using the agreed presets Disabled (0), Default (700), and Large (1000)"
+      - "- [x] step 3: surface the configured threshold in /pruner status and any other existing user-facing config summaries"
+      - "- [x] step 4: add the pre-summarization raw-character guard in flushPending after final batch grouping and before summarizer calls"
+      - "- [x] step 5: implement the disabled path as an explicit gate so value 0 bypasses the guard entirely"
+      - "- [x] step 6: route undersized batches through the existing skip bookkeeping with a distinct reason while preserving frontier advancement and leaving raw tool results in context"
+      - "- [x] step 7: update help text and docs to explain the threshold setting, its presets, its motivation, and how it interacts with existing skip-oversized behavior"
+  - phase: validation
+    steps:
+      - "- [ ] step 1: add or update tests covering Disabled (0), Default/Large threshold skips, and normal prune behavior above the threshold"
+      - "- [ ] step 2: verify existing oversized-summary skip behavior still works unchanged alongside the new pre-summarization guard"
+      - "- [ ] step 3: verify /pruner now and agentic-auto flows report sensible results when batches are skipped as undersized"
+      - "- [ ] step 4: run a reproducible verification command and record the outcome in the final report"
+---
+
+# 031-min-raw-threshold-setting-and-skip-flow
+
+## Threshold rationale
+- **Default = 700 chars:** chosen because the typical summary size we observed for small tool-call batches was roughly **600–700 chars**, so a lower threshold would still send many poor compression candidates to the summarizer.
+- **Large = 1000 chars:** offered as a more conservative preset for users who want to prune only clearly larger raw-output batches.
+- **Disabled = 0 chars:** keeps the old behavior for users who want the existing post-summary oversized check to be the only guard.
+
+## Alternatives considered
+- **Deferred coalescing of tiny batches for later pruning:** rejected for this change because it would alter current batching/frontier semantics and create ambiguity around when previously skipped small batches should be retried.
+- **Relying only on the existing skip-oversized check:** rejected because it still pays summarizer cost for obviously tiny batches that are predictably poor candidates for compression.
+- **Token-count threshold instead of raw character count:** rejected because token estimation adds extra complexity and precision we do not need for this approximate guard.
+
+## Phase 1 — Implementation
+- [x] step 1: add minRawCharsToPrune to shared types and default config with values persisted through settings.json
+- [x] step 2: wire the setting into /pruner settings using the agreed presets Disabled (0), Default (700), and Large (1000)
+- [x] step 3: surface the configured threshold in /pruner status and any other existing user-facing config summaries
+- [x] step 4: add the pre-summarization raw-character guard in flushPending after final batch grouping and before summarizer calls
+- [x] step 5: implement the disabled path as an explicit gate so value 0 bypasses the guard entirely
+- [x] step 6: route undersized batches through the existing skip bookkeeping with a distinct reason while preserving frontier advancement and leaving raw tool results in context
+- [x] step 7: update help text and docs to explain the threshold setting, its presets, its motivation, and how it interacts with existing skip-oversized behavior
+
+## Phase 2 — Validation
+- [ ] step 1: add or update tests covering Disabled (0), Default/Large threshold skips, and normal prune behavior above the threshold
+- [ ] step 2: verify existing oversized-summary skip behavior still works unchanged alongside the new pre-summarization guard
+- [ ] step 3: verify /pruner now and agentic-auto flows report sensible results when batches are skipped as undersized
+- [ ] step 4: run a reproducible verification command and record the outcome in the final report

--- a/PRUNING.md
+++ b/PRUNING.md
@@ -546,6 +546,7 @@ graph LR
 
 The `pi-context-prune` extension includes several mechanisms to ensure pruning is safe, transparent, and configurable:
 
+- **Minimum Raw-Size Guard (`minRawCharsToPrune`):** Before calling the summarizer, the pruner can skip obviously tiny batches whose raw tool-result text falls below a configured minimum (for example `700` chars by default). This avoids paying summarizer cost for small batches that are unlikely to compress well. The frontier still advances, and the original raw text remains in context.
 - **Oversized Summary Skipping (`skip-oversized`):** Occasionally, a batch of tool calls produces very little raw text, and the LLM's summary ends up being *larger* than the original content. When this happens, the pruner detects it and automatically skips pruning that batch. The frontier advances, but the original raw text remains in context to save tokens.
 - **Tree Browser (`/pruner tree`):** You can visually explore all pruned tool calls in your current session using an interactive, foldable tree UI. Selecting a summary lets you inspect its contents directly.
 - **Agentic-Auto Unpruned Count Reminder (`remindUnprunedCount`):** In `agentic-auto` mode, the agent decides when to prune. To help the LLM maintain a healthy cadence, the extension appends a tiny ephemeral `<pruner-note>` to the last tool result before each generation, reminding the model exactly how many unpruned tool calls have piled up in context.

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ The extension registers the `/pruner` command:
 | `/pruner settings` | Opens an interactive settings overlay |
 | `/pruner on` | Enable pruning |
 | `/pruner off` | Disable pruning |
-| `/pruner status` | Show enabled state, summarizer model, thinking level, prune trigger, and cumulative stats |
+| `/pruner status` | Show enabled state, summarizer model, thinking level, prune trigger, min raw threshold, and cumulative stats |
 | `/pruner model` | Show current summarizer model |
 | `/pruner model <id>` | Set summarizer model (e.g. `anthropic/claude-haiku-3-5`) |
 | `/pruner model <id>:<thinking>` | Set summarizer model and thinking together (e.g. `openai/gpt-5-mini:low`) |
@@ -150,13 +150,16 @@ The extension registers the `/pruner` command:
 
 ### Settings overlay
 
-`/pruner settings` opens a TUI overlay with five interactive items:
+`/pruner settings` opens a TUI overlay with eight interactive items:
 
 1. **Enabled** — toggle pruning on/off
 2. **Prune status line** — show or hide the footer status widget and queued turn notifications
 3. **Prune trigger** — cycle through all five `pruneOn` modes
 4. **Summarizer model** — press Enter to open a searchable submenu listing `"default"` plus all available models
 5. **Summarizer thinking** — cycle through the thinking/reasoning level used for summarizer calls
+6. **Min raw chars to prune** — choose `Disabled (0)`, `Default (700)`, or `Large (1000)` for the pre-summarization raw-size guard
+7. **Remind unpruned count** — toggle the agentic-auto reminder note
+8. **Batching mode** — choose whether summaries are per turn or per agent message span
 
 All changes are saved immediately to `~/.pi/agent/context-prune/settings.json` and reflected in the footer status widget when it is enabled.
 
@@ -181,6 +184,7 @@ When the model calls `context_prune`:
 - All pending tool-call batches are summarized together (parallel one-call-per-batch by default, or sequentially in `/pruner now` so the overlay can show live progress)
 - While the tool is running, compact live progress is streamed into the tool output box above the input (for example `Context prune running… batch 2/4 · 1.2k chars received`)
 - If the summary is smaller than the raw tool-result text it would replace, the original outputs are pruned from future context and a summary message is injected as a steer
+- If the batch's raw tool-result text is below the configured minimum prune threshold, pruning is skipped quietly for that attempted range before the summarizer runs: the original tool results remain in context, and the prune frontier still advances
 - If the summary is larger than the raw tool-result text, pruning is skipped for that attempted range: the original tool results remain in context, but the prune frontier still advances so the next prune attempt starts after that range instead of retrying it forever
 
 The tool is guided by a system prompt that instructs the model to use it after completing a meaningful batch of work (not after every trivial call).
@@ -196,7 +200,9 @@ Config is stored in `~/.pi/agent/context-prune/settings.json` (global, project-i
   "summarizerModel": "default",
   "summarizerThinking": "default",
   "pruneOn": "agent-message",
-  "remindUnprunedCount": true
+  "minRawCharsToPrune": 700,
+  "remindUnprunedCount": true,
+  "batchingMode": "turn"
 }
 ```
 
@@ -207,9 +213,12 @@ Config is stored in `~/.pi/agent/context-prune/settings.json` (global, project-i
 | `summarizerModel` | `"default"` or `"provider/model-id"` | `"default"` |
 | `summarizerThinking` | `"default"`, `"off"`, `"minimal"`, `"low"`, `"medium"`, `"high"`, `"xhigh"` | `"default"` |
 | `pruneOn` | `"every-turn"`, `"on-context-tag"`, `"on-demand"`, `"agent-message"`, `"agentic-auto"` | `"agent-message"` |
+| `minRawCharsToPrune` | `0`, `700`, `1000` | `700` |
 | `remindUnprunedCount` | `true` / `false` | `true` |
+| `batchingMode` | `"turn"`, `"agent-message"` | `"turn"` |
 
 - `showPruneStatusLine: true` keeps the prune footer widget and the automatic queued-turn notice visible. Turn it off if you want pruning to stay active without the extra status noise.
+- `minRawCharsToPrune: 700` skips obviously tiny batches before the summarizer runs. Set it to `0` to disable the guard, or `1000` to prune only larger raw tool-output batches.
 - `remindUnprunedCount: true` appends a small ephemeral `<pruner-note>` to the last tool result before each LLM call to remind the model of the number of unpruned tool calls in context. This only has an effect when `pruneOn` is set to `"agentic-auto"`.
 
 - `summarizerModel: "default"` means the current active Pi model. An explicit value like `"anthropic/claude-haiku-3-5"` uses that model for summarization (must be registered in Pi and have an API key).

--- a/index.ts
+++ b/index.ts
@@ -57,7 +57,7 @@ export default function (pi: ExtensionAPI) {
   let isFlushing = false;
 
   type FlushResult =
-    | { ok: true; reason: "flushed" | "skipped-oversized"; batchCount: number; toolCallCount: number; rawCharCount: number; summaryCharCount: number }
+    | { ok: true; reason: "flushed" | "skipped-oversized" | "skipped-too-small" | "skipped"; batchCount: number; toolCallCount: number; rawCharCount: number; summaryCharCount: number }
     | { ok: false; reason: "empty" | "already-flushing" | "summarizer-failed" | "stale-context" | "failed" | "aborted"; error?: string };
 
   type SessionAppender = {
@@ -69,6 +69,8 @@ export default function (pi: ExtensionAPI) {
     err instanceof Error && err.message.includes("This extension ctx is stale");
 
   const errorMessage = (err: unknown) => (err instanceof Error ? err.message : String(err));
+
+  const batchRawCharCount = (batch: CapturedBatch) => batch.toolCalls.reduce((sum, tc) => sum + tc.resultText.length, 0);
 
   const safeNotify = (ctx: any, message: string, type: "info" | "warning" | "error" = "info") => {
     try {
@@ -198,13 +200,32 @@ export default function (pi: ExtensionAPI) {
         options.onBatchTextProgress?.(index, total, batch, receivedChars);
       };
 
-      // Summarize batches. When onProgress is provided (i.e. /pruner now with the
-      // multi-row overlay) we process sequentially so each row can be checked off
-      // as its LLM call completes. Otherwise all batches run in parallel.
-      let results: (import("./src/types.js").SummarizeResult | null)[];
+      const minRawCharsToPrune = currentConfig.value.minRawCharsToPrune;
+      const shouldSkipTooSmall = (batch: CapturedBatch) =>
+        minRawCharsToPrune > 0 && batchRawCharCount(batch) < minRawCharsToPrune;
+
+      type BatchOutcome =
+        | { kind: "too-small" }
+        | { kind: "summarized"; result: import("./src/types.js").SummarizeResult }
+        | { kind: "failed" };
+
+      const outcomes: BatchOutcome[] = batches.map((batch) =>
+        shouldSkipTooSmall(batch) ? { kind: "too-small" } : { kind: "failed" }
+      );
+      const eligibleIndexes = batches
+        .map((batch, index) => (shouldSkipTooSmall(batch) ? -1 : index))
+        .filter((index) => index >= 0);
+
+      // Summarize eligible batches. When onProgress is provided (i.e. /pruner now
+      // with the multi-row overlay) we process sequentially so each row can be
+      // checked off as its LLM call completes. Otherwise all eligible batches run
+      // in parallel. Undersized batches are skipped before any LLM call.
       if (options.onProgress) {
-        results = [];
         for (let i = 0; i < batches.length; i++) {
+          if (outcomes[i]?.kind === "too-small") {
+            options.onProgress(i, batches.length, batches[i], "skipped");
+            continue;
+          }
           options.onProgress(i, batches.length, batches[i], "start");
           const r = await summarizeBatch(batches[i], currentConfig.value, ctx, {
             signal: options.signal,
@@ -212,44 +233,64 @@ export default function (pi: ExtensionAPI) {
               reportBatchTextProgress(i, batches.length, batches[i], receivedChars);
             },
           });
-          results.push(r);
+          outcomes[i] = r ? { kind: "summarized", result: r } : { kind: "failed" };
           options.onProgress(i, batches.length, batches[i], r ? "done" : "skipped");
         }
-      } else {
-        // Parallel — one LLM call per batch, all in flight simultaneously.
-        results = await summarizeBatches(batches, currentConfig.value, ctx, {
-          onBatchTextProgress: reportBatchTextProgress,
+      } else if (eligibleIndexes.length > 0) {
+        const eligibleBatches = eligibleIndexes.map((index) => batches[index]);
+        const results = await summarizeBatches(eligibleBatches, currentConfig.value, ctx, {
+          onBatchTextProgress: (eligibleIndex, _total, batch, receivedChars) => {
+            const originalIndex = eligibleIndexes[eligibleIndex] ?? eligibleIndex;
+            reportBatchTextProgress(originalIndex, batches.length, batch, receivedChars);
+          },
           signal: options.signal,
         });
+        for (let i = 0; i < eligibleIndexes.length; i++) {
+          const originalIndex = eligibleIndexes[i];
+          const result = results[i];
+          outcomes[originalIndex] = result ? { kind: "summarized", result } : { kind: "failed" };
+        }
       }
 
-      // Process results in order; stop at first null (individual call failure).
-      // Batches before the first failure are persisted; remaining are restored to
-      // pendingBatches so they are retried on the next flush.
+      // Process outcomes in order; stop at first failed summarizer call.
+      // Batches before the first failure are persisted or marked skipped;
+      // remaining are restored to pendingBatches so they are retried later.
       const processedBatches: CapturedBatch[] = [];
       let totalRawCharCount = 0;
       let totalSummaryCharCount = 0;
       let totalToolCallCount = 0;
       const oversizedBatches: CapturedBatch[] = [];
+      const tooSmallBatches: CapturedBatch[] = [];
       let firstFailureIndex = -1;
+      let persistedSummaryCount = 0;
 
       for (let i = 0; i < batches.length; i++) {
-        const result = results[i];
-        if (!result) {
+        const outcome = outcomes[i];
+        const batch = batches[i];
+        const rawCharCount = batchRawCharCount(batch);
+        totalRawCharCount += rawCharCount;
+        totalToolCallCount += batch.toolCalls.length;
+
+        if (!outcome || outcome.kind === "failed") {
+          totalRawCharCount -= rawCharCount;
+          totalToolCallCount -= batch.toolCalls.length;
           firstFailureIndex = i;
           break;
         }
 
-        const batch = batches[i];
-        const batchRawCharCount = batch.toolCalls.reduce((s, tc) => s + tc.resultText.length, 0);
+        if (outcome.kind === "too-small") {
+          tooSmallBatches.push(batch);
+          processedBatches.push(batch);
+          continue;
+        }
+
+        const result = outcome.result;
         const summaryRefs = indexer.allocateSummaryRefs(batch);
         const summaryText = result.summaryText + formatSummaryToolCallRefs(summaryRefs);
-        const shouldSkipOversized = summaryText.length > batchRawCharCount;
+        const shouldSkipOversized = summaryText.length > rawCharCount;
 
         statsAccum.add(result.usage);
-        totalRawCharCount += batchRawCharCount;
         totalSummaryCharCount += summaryText.length;
-        totalToolCallCount += batch.toolCalls.length;
 
         const batchDetails = makeSummaryDetails(batch, summaryRefs);
 
@@ -268,6 +309,7 @@ export default function (pi: ExtensionAPI) {
               indexer.registerSummaryRefs(summaryRefs);
               persistBatchIndex(batch, appendEntry);
             }
+            persistedSummaryCount += 1;
           } else {
             oversizedBatches.push(batch);
           }
@@ -299,6 +341,18 @@ export default function (pi: ExtensionAPI) {
       const lastBatch = processedBatches[processedBatches.length - 1];
       const lastTC = lastBatch.toolCalls[lastBatch.toolCalls.length - 1];
       const allOversized = oversizedBatches.length === processedBatches.length;
+      const allTooSmall = tooSmallBatches.length === processedBatches.length;
+      const anySkipped = oversizedBatches.length > 0 || tooSmallBatches.length > 0;
+      const outcome =
+        persistedSummaryCount > 0
+          ? "summarized"
+          : allTooSmall
+            ? "skipped-too-small"
+            : allOversized
+              ? "skipped-oversized"
+              : anySkipped
+                ? "skipped"
+                : "summarized";
       const frontierSnapshot: PruneFrontier = {
         lastAttemptedToolCallId: lastTC.toolCallId,
         lastAttemptedToolName: lastTC.toolName,
@@ -308,7 +362,7 @@ export default function (pi: ExtensionAPI) {
         attemptedToolCallCount: totalToolCallCount,
         rawCharCount: totalRawCharCount,
         summaryCharCount: totalSummaryCharCount,
-        outcome: allOversized ? "skipped-oversized" : "summarized",
+        outcome,
       };
 
       try {
@@ -333,8 +387,9 @@ export default function (pi: ExtensionAPI) {
 
       // Notify about any oversized batches that were skipped
       for (const batch of oversizedBatches) {
-        const batchRaw = batch.toolCalls.reduce((s, tc) => s + tc.resultText.length, 0);
-        const batchSummaryLen = results[batches.indexOf(batch)]?.summaryText.length ?? 0;
+        const batchRaw = batchRawCharCount(batch);
+        const batchOutcome = outcomes[batches.indexOf(batch)];
+        const batchSummaryLen = batchOutcome?.kind === "summarized" ? batchOutcome.result.summaryText.length : 0;
         safeNotify(
           ctx,
           `pruner: skipped pruning turn ${batch.turnIndex} (${batch.toolCalls.length} tool call${batch.toolCalls.length === 1 ? "" : "s"}) — summary was ${batchSummaryLen} chars vs ${batchRaw} raw chars; frontier advanced past this range`,
@@ -344,7 +399,16 @@ export default function (pi: ExtensionAPI) {
 
       return {
         ok: true,
-        reason: allOversized ? "skipped-oversized" : "flushed",
+        reason:
+          persistedSummaryCount > 0
+            ? "flushed"
+            : allTooSmall
+              ? "skipped-too-small"
+              : allOversized
+                ? "skipped-oversized"
+                : anySkipped
+                  ? "skipped"
+                  : "flushed",
         batchCount: processedBatches.length,
         toolCallCount: totalToolCallCount,
         rawCharCount: totalRawCharCount,

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -73,7 +73,7 @@ const SUBCOMMANDS = [
   { value: "settings", label: "settings  — interactive settings overlay" },
   { value: "on",       label: "on        — enable context pruning" },
   { value: "off",      label: "off       — disable context pruning" },
-  { value: "status",  label: "status    — show status, model, thinking, prune trigger, and status line" },
+  { value: "status",  label: "status    — show status, model, thinking, prune trigger, threshold, and status line" },
   { value: "model",   label: "model     — show or set the summarizer model" },
   { value: "thinking", label: "thinking  — show or set the summarizer thinking level" },
   { value: "prune-on", label: "prune-on  — show or set the trigger mode" },
@@ -167,13 +167,30 @@ function pruneStatusLineDescription(config: ContextPruneConfig): string {
   return `Hide the prune footer status line and queued turn notifications. Currently ${base}.`;
 }
 
+const MIN_RAW_CHARS_PRESETS = [
+  { value: 0, label: "Disabled" },
+  { value: 700, label: "Default" },
+  { value: 1000, label: "Large" },
+] as const;
+
+function minRawCharsPresetLabel(value: number): string {
+  return MIN_RAW_CHARS_PRESETS.find((preset) => preset.value === value)?.label ?? `${value} chars`;
+}
+
+function minRawCharsDescription(value: number): string {
+  if (value === 0) {
+    return "No minimum raw-size guard. Every pending batch can be summarized, then the existing oversized-summary check still decides whether pruning is kept.";
+  }
+  return `Only summarize batches whose raw tool-result text is at least ${value} chars. Smaller batches are skipped quietly before the summarizer runs.`;
+}
+
 const HELP_TEXT = `pruner — automatically summarizes tool-call outputs to keep context lean.
 
 Usage:
   /pruner settings                         Interactive settings overlay
   /pruner on                               Enable context pruning
   /pruner off                              Disable context pruning
-  /pruner status                           Show status, model, prune trigger, batching mode, and stats
+  /pruner status                           Show status, model, prune trigger, batching mode, threshold, and stats
   /pruner model                            Show the current summarizer model
   /pruner model <id>                       Set summarizer model (e.g. anthropic/claude-haiku-3-5)
   /pruner model <id>:<thinking>            Set summarizer model and thinking together (e.g. openai/gpt-5-mini:low)
@@ -204,6 +221,11 @@ Batching mode:
   - turn (default): each assistant turn that used tools gets its own summary block. Small, granular.
   - agent-message: all assistant turns between two consecutive user messages are merged into one summary.
     Use this when a single user request triggers many back-to-back tool rounds that belong together.
+
+Minimum raw-size guard:
+  - Disabled (0): do not pre-skip small batches; let the existing oversized-summary check decide after summarization.
+  - Default (700): skip obviously tiny batches quietly before the summarizer runs. This avoids paying summarizer cost when summaries are usually larger than the raw output.
+  - Large (1000): be more conservative and summarize only larger raw tool-output batches.
 
 Mode guidance:
   - every-turn: only for debugging / testing summary behavior. Rewrites earlier context too often and can repeatedly bust provider prompt caches.
@@ -346,7 +368,7 @@ export function registerCommands(
   pi: ExtensionAPI,
   currentConfig: { value: ContextPruneConfig },
   flushPending: (ctx: ExtensionCommandContext, options?: FlushOptions) => Promise<
-    | { ok: true; reason: "flushed" | "skipped-oversized"; batchCount: number; toolCallCount: number; rawCharCount: number; summaryCharCount: number }
+    | { ok: true; reason: "flushed" | "skipped-oversized" | "skipped-too-small" | "skipped"; batchCount: number; toolCallCount: number; rawCharCount: number; summaryCharCount: number }
     | { ok: false; reason: string; error?: string }
   >,
   capturePendingBatches: (ctx: ExtensionCommandContext) => CapturedBatch[],
@@ -447,6 +469,13 @@ export function registerCommands(
               description: summarizerThinkingDescription(config.summarizerThinking),
             },
             {
+              id: "minRawCharsToPrune",
+              label: "Min raw chars to prune",
+              values: MIN_RAW_CHARS_PRESETS.map((preset) => String(preset.value)),
+              currentValue: String(config.minRawCharsToPrune),
+              description: minRawCharsDescription(config.minRawCharsToPrune),
+            },
+            {
               id: "remindUnprunedCount",
               label: "Remind unpruned count",
               values: ["true", "false"],
@@ -492,6 +521,12 @@ export function registerCommands(
               const thinkingItem = items.find((item) => item.id === "summarizerThinking");
               if (thinkingItem) {
                 thinkingItem.description = summarizerThinkingDescription(newConfig.summarizerThinking);
+              }
+            } else if (id === "minRawCharsToPrune") {
+              newConfig.minRawCharsToPrune = Number(newValue);
+              const thresholdItem = items.find((item) => item.id === "minRawCharsToPrune");
+              if (thresholdItem) {
+                thresholdItem.description = minRawCharsDescription(newConfig.minRawCharsToPrune);
               }
             } else if (id === "remindUnprunedCount") {
               newConfig.remindUnprunedCount = newValue === "true";
@@ -573,7 +608,7 @@ export function registerCommands(
             ? `\n  --- summarizer ---\n  calls:       ${s.callCount}\n  input:       ${formatTokens(s.totalInputTokens)} tokens\n  output:      ${formatTokens(s.totalOutputTokens)} tokens\n  cost:        ${formatCost(s.totalCost)}`
             : "\n  (no summarizer calls yet)";
           ctx.ui.notify(
-            `pruner status:\n  enabled:  ${cfg.enabled}\n  model:    ${cfg.summarizerModel}\n  thinking: ${summarizerThinkingLabel(cfg.summarizerThinking)} (${cfg.summarizerThinking})\n  trigger:  ${mode}\n  batching: ${batchingModeLabel(cfg.batchingMode)} (${cfg.batchingMode})\n  status:   ${cfg.showPruneStatusLine ? "on" : "off"}\n  remind:   ${cfg.remindUnprunedCount ? "on" : "off"} (agentic-auto only)${statsLine}`,
+            `pruner status:\n  enabled:   ${cfg.enabled}\n  model:     ${cfg.summarizerModel}\n  thinking:  ${summarizerThinkingLabel(cfg.summarizerThinking)} (${cfg.summarizerThinking})\n  trigger:   ${mode}\n  batching:  ${batchingModeLabel(cfg.batchingMode)} (${cfg.batchingMode})\n  min raw:   ${minRawCharsPresetLabel(cfg.minRawCharsToPrune)} (${cfg.minRawCharsToPrune})\n  status:    ${cfg.showPruneStatusLine ? "on" : "off"}\n  remind:    ${cfg.remindUnprunedCount ? "on" : "off"} (agentic-auto only)${statsLine}`,
           );
           break;
         }
@@ -753,6 +788,14 @@ export function registerCommands(
             ctx.ui.notify(
               `pruner: skipped pruning ${result.toolCallCount} tool call${result.toolCallCount === 1 ? "" : "s"} — summary was ${result.summaryCharCount} chars vs ${result.rawCharCount} raw chars; frontier advanced past this range`,
               "warning"
+            );
+            break;
+          }
+
+          if (result.reason === "skipped-too-small" || result.reason === "skipped") {
+            ctx.ui.notify(
+              `pruner: skipped ${result.toolCallCount} tool call${result.toolCallCount === 1 ? "" : "s"} from ${result.batchCount} batch${result.batchCount === 1 ? "" : "es"} — raw tool-result text stayed below the configured minimum (${currentConfig.value.minRawCharsToPrune} chars), so the original results were kept and the frontier advanced`,
+              "info"
             );
             break;
           }

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,7 +2,7 @@ import { readFile, writeFile, mkdir } from "node:fs/promises";
 import { join, dirname } from "node:path";
 import { homedir } from "node:os";
 import type { ContextPruneConfig, PruneOn, SummarizerThinking } from "./types.js";
-import { DEFAULT_CONFIG, PRUNE_ON_MODES, SUMMARIZER_THINKING_LEVELS } from "./types.js";
+import { DEFAULT_CONFIG, MIN_RAW_CHARS_TO_PRUNE_PRESETS, PRUNE_ON_MODES, SUMMARIZER_THINKING_LEVELS } from "./types.js";
 
 /** Path to the extension's own settings file, independent of any project. */
 export const SETTINGS_PATH = join(homedir(), ".pi", "agent", "context-prune", "settings.json");
@@ -13,6 +13,14 @@ function isPruneOn(value: unknown): value is PruneOn {
 
 function isSummarizerThinking(value: unknown): value is SummarizerThinking {
   return typeof value === "string" && SUMMARIZER_THINKING_LEVELS.some((level) => level.value === value);
+}
+
+function normalizeMinRawCharsToPrune(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) return DEFAULT_CONFIG.minRawCharsToPrune;
+  const rounded = Math.max(0, Math.round(value));
+  return MIN_RAW_CHARS_TO_PRUNE_PRESETS.includes(rounded as (typeof MIN_RAW_CHARS_TO_PRUNE_PRESETS)[number])
+    ? rounded
+    : DEFAULT_CONFIG.minRawCharsToPrune;
 }
 
 /** Reads ~/.pi/agent/context-prune/settings.json and returns the config (or defaults). */
@@ -29,6 +37,7 @@ export async function loadConfig(): Promise<ContextPruneConfig> {
           ? merged.showPruneStatusLine
           : DEFAULT_CONFIG.showPruneStatusLine,
       pruneOn: isPruneOn(merged.pruneOn) ? merged.pruneOn : DEFAULT_CONFIG.pruneOn,
+      minRawCharsToPrune: normalizeMinRawCharsToPrune(merged.minRawCharsToPrune),
       summarizerThinking: isSummarizerThinking(merged.summarizerThinking)
         ? merged.summarizerThinking
         : DEFAULT_CONFIG.summarizerThinking,

--- a/src/context-prune-tool.ts
+++ b/src/context-prune-tool.ts
@@ -23,6 +23,7 @@ import { pruneProgressText } from "./progress-text.js";
 type FlushResult =
   | { ok: true; reason: "flushed"; batchCount: number; toolCallCount: number; rawCharCount: number; summaryCharCount: number }
   | { ok: true; reason: "skipped-oversized"; batchCount: number; toolCallCount: number; rawCharCount: number; summaryCharCount: number }
+  | { ok: true; reason: "skipped-too-small" | "skipped"; batchCount: number; toolCallCount: number; rawCharCount: number; summaryCharCount: number }
   | { ok: false; reason: string; error?: string };
 
 function sendToolProgress(
@@ -95,6 +96,18 @@ export function registerContextPruneTool(
               {
                 type: "text",
                 text: `Context prune skipped ${result.toolCallCount} tool call${result.toolCallCount === 1 ? "" : "s"}: the summary was ${result.summaryCharCount} chars while the raw tool results were ${result.rawCharCount} chars. The original tool results were kept, and the prune frontier advanced so the next prune starts after this range.`,
+              },
+            ],
+            details: result,
+          };
+        }
+
+        if (result.reason === "skipped-too-small" || result.reason === "skipped") {
+          return {
+            content: [
+              {
+                type: "text",
+                text: `Context prune skipped ${result.toolCallCount} tool call${result.toolCallCount === 1 ? "" : "s"}: the raw tool-result text stayed below the configured minimum prune threshold, so the original results were kept and the prune frontier advanced past this range.`,
               },
             ],
             details: result,

--- a/src/types.ts
+++ b/src/types.ts
@@ -118,6 +118,8 @@ export type BatchingMode = "turn" | "agent-message";
 export type SummarizerThinking = "default" | "off" | "minimal" | "low" | "medium" | "high" | "xhigh";
 
 /** Choices for the summarizer thinking setting (used by commands and settings overlay) */
+export const MIN_RAW_CHARS_TO_PRUNE_PRESETS = [0, 700, 1000] as const;
+
 export const SUMMARIZER_THINKING_LEVELS: { value: SummarizerThinking; label: string }[] = [
   { value: "default", label: "Default" },
   { value: "off", label: "Off" },
@@ -160,6 +162,11 @@ export interface ContextPruneConfig {
   /** When to trigger summarization and pruning */
   pruneOn: PruneOn;
   /**
+   * Minimum raw tool-result character count required before a batch is even
+   * considered for summarization. 0 disables this pre-summarization guard.
+   */
+  minRawCharsToPrune: number;
+  /**
    * Whether to inject a small ephemeral reminder before each LLM call
    * telling the model how many unpruned tool-call results have piled up.
    * Only honored when `enabled && pruneOn === "agentic-auto"`. In all other
@@ -182,6 +189,7 @@ export const DEFAULT_CONFIG: ContextPruneConfig = {
   summarizerModel: "default",
   summarizerThinking: "default",
   pruneOn: "agent-message",
+  minRawCharsToPrune: 700,
   remindUnprunedCount: true,
   batchingMode: "turn",
 };
@@ -284,7 +292,7 @@ export interface SummarizerStats {
 }
 
 /** Outcome of the most recent completed prune attempt. */
-export type PruneFrontierOutcome = "summarized" | "skipped-oversized";
+export type PruneFrontierOutcome = "summarized" | "skipped-oversized" | "skipped-too-small" | "skipped";
 
 /**
  * Snapshot of the last successfully completed prune attempt boundary.


### PR DESCRIPTION
## Summary

Add a configurable pre-summarization raw-size guard so tiny tool-result batches can be skipped before the summarizer runs.

This avoids spending summarizer calls on batches that are unlikely to compress well, while preserving the existing oversized-summary safeguard.

## Changes

- add `minRawCharsToPrune` config
  - `0` = Disabled
  - `700` = Default
  - `1000` = Large
- add the setting to `/pruner settings`
- show the configured threshold in `/pruner status`
- add a pre-summarization guard in `flushPending()`
- treat `0` as an explicit bypass of the guard
- skip undersized batches before any LLM call
- keep raw tool results in context for undersized batches
- still advance the prune frontier for undersized batches
- preserve existing `skipped-oversized` behavior
- update README / PRUNING docs

## Behavior

Before:
- every pending batch could reach the summarizer
- only after summarization would we skip if the summary was larger than the raw content

After:
- if a batch has raw tool-result text below `minRawCharsToPrune`, it is skipped before summarization
- original tool results remain in context
- prune frontier still advances past that range
- oversized-summary skipping still works as before for eligible batches

## Motivation

[Issue #11](https://github.com/championswimmer/pi-context-prune/issues/11) reported repeated cases where very small batches produced summaries larger than the raw content.
This change adds a cheap approximate guard using raw character count instead of token estimation.

## Why 700?

The default was set to `700` because the typical summary size observed for small tool-call batches was around `600–700` characters, so lower thresholds still allowed many poor compression candidates through to the summarizer. 

## Validation

Ran successfully:
- `./node_modules/.bin/tsc --noEmit --module nodenext --moduleResolution nodenext --target es2022 --skipLibCheck index.ts src/*.ts`
- `npm run check`
- `npm run build`
- `git diff --check`

## Notes

- no new top-level `/pruner` subcommand was added
- the new control lives inside `/pruner settings` as **Min raw chars to prune**
