### PR TITLE
Fix compact after context pruning

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -13,7 +13,7 @@
  * Usage:  pi -e .
  */
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { compact, type ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { loadConfig } from "./src/config.js";
 import { captureBatch, captureUnindexedBatchesFromSession, groupBatchesByMode } from "./src/batch-capture.js";
 import { summarizeBatch, summarizeBatches } from "./src/summarizer.js";
@@ -36,6 +36,7 @@ import {
 import { StatsAccumulator } from "./src/stats.js";
 import { registerContextPruneTool } from "./src/context-prune-tool.js";
 import { PruneFrontierTracker } from "./src/frontier.js";
+import { mergeCompactSanitizeStats, sanitizeMessagesForCompact } from "./src/compact-sanitizer.js";
 
 export default function (pi: ExtensionAPI) {
   // Shared mutable config reference — updated by /pruner commands
@@ -421,6 +422,76 @@ export default function (pi: ExtensionAPI) {
     frontier.reconstructFromSession(ctx);
     // Pending batches belong to the old branch — discard them
     pendingBatches.length = 0;
+  });
+
+  // ── session_before_compact: keep Pi /compact from re-sending pruned raw outputs ──
+  pi.on("session_before_compact", async (event, ctx) => {
+    // Native Pi compaction is built from the raw session branch, so it does not see
+    // this extension's normal context-event pruning. If we have indexed tool calls,
+    // compact a sanitized view that keeps context-prune-summary messages but drops
+    // the already-summarized raw tool results and large tool-call arguments.
+    if (indexer.getIndex().size === 0) return undefined;
+
+    const summarized = sanitizeMessagesForCompact(event.preparation.messagesToSummarize, indexer);
+    const turnPrefix = sanitizeMessagesForCompact(event.preparation.turnPrefixMessages, indexer);
+    const stats = mergeCompactSanitizeStats(summarized.stats, turnPrefix.stats);
+
+    if (!stats.changed) return undefined;
+
+    const model = ctx.model;
+    if (!model) {
+      safeNotify(ctx, "pruner: cancelled compact because no active model was available for sanitized compaction", "error");
+      return { cancel: true };
+    }
+
+    const auth = await ctx.modelRegistry.getApiKeyAndHeaders(model);
+    if (!auth.ok) {
+      const authMessage = "error" in auth ? auth.error : "authentication failed";
+      safeNotify(ctx, `pruner: cancelled compact because sanitized compaction auth failed: ${authMessage}`, "error");
+      return { cancel: true };
+    }
+
+    try {
+      safeNotify(
+        ctx,
+        `pruner: compact is using sanitized history (dropped ${stats.droppedToolResults} pruned tool results, replaced ${stats.replacedToolCalls} tool calls)`,
+        "info"
+      );
+
+      const result = await compact(
+        {
+          ...event.preparation,
+          messagesToSummarize: summarized.messages as any,
+          turnPrefixMessages: turnPrefix.messages as any,
+        },
+        model,
+        auth.apiKey,
+        auth.headers,
+        event.customInstructions,
+        event.signal
+      );
+
+      return {
+        compaction: {
+          ...result,
+          details: {
+            ...(result.details as any),
+            contextPrune: {
+              sanitized: true,
+              droppedToolResults: stats.droppedToolResults,
+              replacedToolCalls: stats.replacedToolCalls,
+              summaryMessagesSeen: stats.summaryMessagesSeen,
+              beforeChars: stats.beforeChars,
+              afterChars: stats.afterChars,
+            },
+          },
+        },
+      };
+    } catch (err) {
+      if (event.signal.aborted) return { cancel: true };
+      safeNotify(ctx, `pruner: sanitized compaction failed: ${errorMessage(err)}`, "error");
+      throw err;
+    }
   });
 
   // ── turn_end: capture batch, flush immediately or queue ──────────────────

--- a/src/compact-sanitizer.ts
+++ b/src/compact-sanitizer.ts
@@ -1,0 +1,130 @@
+import { CUSTOM_TYPE_SUMMARY } from "./types.js";
+
+interface CompactToolCallIndex {
+  isSummarized(toolCallId: string): boolean;
+  getRecord(toolCallId: string): { toolName?: string; args?: any } | undefined;
+}
+
+export interface CompactSanitizeStats {
+  changed: boolean;
+  droppedToolResults: number;
+  replacedToolCalls: number;
+  summaryMessagesSeen: number;
+  beforeChars: number;
+  afterChars: number;
+}
+
+export interface CompactSanitizeResult<TMessage = any> {
+  messages: TMessage[];
+  stats: CompactSanitizeStats;
+}
+
+const emptyStats = (): CompactSanitizeStats => ({
+  changed: false,
+  droppedToolResults: 0,
+  replacedToolCalls: 0,
+  summaryMessagesSeen: 0,
+  beforeChars: 0,
+  afterChars: 0,
+});
+
+function roughChars(value: unknown): number {
+  if (typeof value === "string") return value.length;
+  try {
+    return JSON.stringify(value)?.length ?? 0;
+  } catch {
+    return String(value).length;
+  }
+}
+
+function shortValue(value: unknown, max = 160): string | undefined {
+  if (value === undefined || value === null) return undefined;
+  const raw = typeof value === "string" ? value : JSON.stringify(value);
+  if (!raw) return undefined;
+  return raw.length <= max ? raw : `${raw.slice(0, max)}…`;
+}
+
+function compactToolCallLabel(block: any, indexer: CompactToolCallIndex): string {
+  const record = indexer.getRecord(block.id);
+  const toolName = record?.toolName ?? block.name ?? "tool";
+  const args = record?.args ?? block.arguments ?? {};
+  const path = typeof args?.path === "string" ? args.path : undefined;
+  const command = typeof args?.command === "string" ? shortValue(args.command, 140) : undefined;
+  const extra = path ? ` path=${path}` : command ? ` command=${command}` : "";
+
+  return [
+    `[context-prune: omitted summarized ${toolName} tool call ${block.id}${extra}.`,
+    `Its raw arguments/result were already replaced by a context-prune-summary message;`,
+    `use context_tree_query if the original output is needed.]`,
+  ].join(" ");
+}
+
+function sanitizeAssistantMessage(message: any, indexer: CompactToolCallIndex, stats: CompactSanitizeStats): any {
+  if (!Array.isArray(message?.content)) return message;
+
+  let changed = false;
+  const content = message.content.map((block: any) => {
+    if (block?.type === "toolCall" && typeof block.id === "string" && indexer.isSummarized(block.id)) {
+      changed = true;
+      stats.replacedToolCalls += 1;
+      return { type: "text", text: compactToolCallLabel(block, indexer) };
+    }
+    return block;
+  });
+
+  if (!changed) return message;
+  stats.changed = true;
+  return { ...message, content };
+}
+
+/**
+ * Build the view Pi should send to its compaction summarizer after this extension
+ * has already summarized tool results. The session tree still contains the raw
+ * results, so native /compact would otherwise re-send them and can exceed the
+ * model window. We keep the pruner summary messages and remove only data that is
+ * recoverable via the context-prune index.
+ */
+export function sanitizeMessagesForCompact<TMessage = any>(
+  messages: TMessage[],
+  indexer: CompactToolCallIndex
+): CompactSanitizeResult<TMessage> {
+  const stats = emptyStats();
+  stats.beforeChars = roughChars(messages);
+
+  const sanitized: any[] = [];
+
+  for (const message of messages as any[]) {
+    if (message?.role === "custom" && message.customType === CUSTOM_TYPE_SUMMARY) {
+      stats.summaryMessagesSeen += 1;
+    }
+
+    if (message?.role === "toolResult" && typeof message.toolCallId === "string" && indexer.isSummarized(message.toolCallId)) {
+      stats.changed = true;
+      stats.droppedToolResults += 1;
+      continue;
+    }
+
+    if (message?.role === "assistant") {
+      sanitized.push(sanitizeAssistantMessage(message, indexer, stats));
+      continue;
+    }
+
+    sanitized.push(message);
+  }
+
+  stats.afterChars = roughChars(sanitized);
+  return { messages: (stats.changed ? sanitized : messages) as TMessage[], stats };
+}
+
+export function mergeCompactSanitizeStats(...items: CompactSanitizeStats[]): CompactSanitizeStats {
+  const merged = emptyStats();
+  for (const item of items) {
+    merged.changed ||= item.changed;
+    merged.droppedToolResults += item.droppedToolResults;
+    merged.replacedToolCalls += item.replacedToolCalls;
+    merged.summaryMessagesSeen += item.summaryMessagesSeen;
+    merged.beforeChars += item.beforeChars;
+    merged.afterChars += item.afterChars;
+  }
+  return merged;
+}

--- a/src/query-tool.ts
+++ b/src/query-tool.ts
@@ -19,7 +19,7 @@ export function registerQueryTool(pi: ExtensionAPI, indexer: ToolCallIndexer): v
       }),
     }),
 
-    async execute(_toolCallId, params, _signal, _onUpdate, _ctx) {
+    async execute(_toolCallId: string, params: any, _signal: AbortSignal, _onUpdate: any, _ctx: any) {
       const foundRecords: Record<string, any> = {};
       const blocks: string[] = [];
 


### PR DESCRIPTION
## Summary
- Sanitize Pi native `/compact` input when context-prune has already summarized tool calls.
- Drop already summarized raw `toolResult` messages before compaction.
- Replace matching assistant `toolCall` blocks with compact placeholders.
- Preserve `context-prune-summary` messages so compaction keeps the pruned context state.

## Why
Native `/compact` builds its summary input from raw session history. Context-prune normally removes large raw tool outputs through the `context` hook without mutating session history, so those raw outputs can still be included when `/compact` runs.

After a pruning pass, this can make `/compact` send already-pruned tool results back to the model and exceed the context window. This change keeps normal pruning non-destructive, but gives native compaction a sanitized view when summarized tool calls already exist.

## Validation
- `npm run check`
- Manual flow passed: prune first, then run `/compact` successfully.
