### PR TITLE
Demote 'skipped pruning oversized' notification to info

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -333,16 +333,18 @@ export default function (pi: ExtensionAPI) {
 
       // Notify about any oversized batches that were skipped. This is not an
       // error condition — the pruner correctly chose not to grow context — so
-      // surface it as info, not a warning, to avoid alarming users on every
-      // small-turn session.
-      for (const batch of oversizedBatches) {
-        const batchRaw = batch.toolCalls.reduce((s, tc) => s + tc.resultText.length, 0);
-        const batchSummaryLen = results[batches.indexOf(batch)]?.summaryText.length ?? 0;
-        safeNotify(
-          ctx,
-          `pruner: skipped pruning turn ${batch.turnIndex} (${batch.toolCalls.length} tool call${batch.toolCalls.length === 1 ? "" : "s"}) — summary was ${batchSummaryLen} chars vs ${batchRaw} raw chars; frontier advanced past this range`,
-          "info"
-        );
+      // surface it as info, not a warning, and let users mute it entirely via
+      // `quietOversizedSkips` for sessions dominated by small tool calls.
+      if (!currentConfig.value.quietOversizedSkips) {
+        for (const batch of oversizedBatches) {
+          const batchRaw = batch.toolCalls.reduce((s, tc) => s + tc.resultText.length, 0);
+          const batchSummaryLen = results[batches.indexOf(batch)]?.summaryText.length ?? 0;
+          safeNotify(
+            ctx,
+            `pruner: skipped pruning turn ${batch.turnIndex} (${batch.toolCalls.length} tool call${batch.toolCalls.length === 1 ? "" : "s"}) — summary was ${batchSummaryLen} chars vs ${batchRaw} raw chars; frontier advanced past this range`,
+            "info"
+          );
+        }
       }
 
       return {

--- a/index.ts
+++ b/index.ts
@@ -331,14 +331,17 @@ export default function (pi: ExtensionAPI) {
 
       setPruneStatusWidget(ctx, currentConfig.value, statsAccum.getStats());
 
-      // Notify about any oversized batches that were skipped
+      // Notify about any oversized batches that were skipped. This is not an
+      // error condition — the pruner correctly chose not to grow context — so
+      // surface it as info, not a warning, to avoid alarming users on every
+      // small-turn session.
       for (const batch of oversizedBatches) {
         const batchRaw = batch.toolCalls.reduce((s, tc) => s + tc.resultText.length, 0);
         const batchSummaryLen = results[batches.indexOf(batch)]?.summaryText.length ?? 0;
         safeNotify(
           ctx,
           `pruner: skipped pruning turn ${batch.turnIndex} (${batch.toolCalls.length} tool call${batch.toolCalls.length === 1 ? "" : "s"}) — summary was ${batchSummaryLen} chars vs ${batchRaw} raw chars; frontier advanced past this range`,
-          "warning"
+          "info"
         );
       }
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -167,6 +167,14 @@ function pruneStatusLineDescription(config: ContextPruneConfig): string {
   return `Hide the prune footer status line and queued turn notifications. Currently ${base}.`;
 }
 
+function quietOversizedSkipsDescription(config: ContextPruneConfig): string {
+  const base = config.quietOversizedSkips ? "ON" : "OFF";
+  if (config.quietOversizedSkips) {
+    return `Suppress the 'skipped pruning … oversized' notification when a summary would have been larger than the raw tool output. The frontier still advances. Currently ${base}.`;
+  }
+  return `Show the 'skipped pruning … oversized' info notification when a summary would have been larger than the raw tool output. Currently ${base}.`;
+}
+
 const HELP_TEXT = `pruner — automatically summarizes tool-call outputs to keep context lean.
 
 Usage:
@@ -460,6 +468,13 @@ export function registerCommands(
               currentValue: config.batchingMode,
               description: batchingModeDescription(config.batchingMode),
             },
+            {
+              id: "quietOversizedSkips",
+              label: "Quiet oversized skips",
+              values: ["true", "false"],
+              currentValue: String(config.quietOversizedSkips),
+              description: quietOversizedSkipsDescription(config),
+            },
           ];
 
           let settingsList: SettingsList;
@@ -508,6 +523,12 @@ export function registerCommands(
               const batchingItem = items.find((item) => item.id === "batchingMode");
               if (batchingItem) {
                 batchingItem.description = batchingModeDescription(newConfig.batchingMode);
+              }
+            } else if (id === "quietOversizedSkips") {
+              newConfig.quietOversizedSkips = newValue === "true";
+              const quietItem = items.find((item) => item.id === "quietOversizedSkips");
+              if (quietItem) {
+                quietItem.description = quietOversizedSkipsDescription(newConfig);
               }
             }
             currentConfig.value = newConfig;

--- a/src/config.ts
+++ b/src/config.ts
@@ -36,6 +36,10 @@ export async function loadConfig(): Promise<ContextPruneConfig> {
         typeof merged.remindUnprunedCount === "boolean"
           ? merged.remindUnprunedCount
           : DEFAULT_CONFIG.remindUnprunedCount,
+      quietOversizedSkips:
+        typeof merged.quietOversizedSkips === "boolean"
+          ? merged.quietOversizedSkips
+          : DEFAULT_CONFIG.quietOversizedSkips,
     };
   } catch {
     return { ...DEFAULT_CONFIG };

--- a/src/types.ts
+++ b/src/types.ts
@@ -174,6 +174,13 @@ export interface ContextPruneConfig {
    *                     (all turns between two user messages are merged)
    */
   batchingMode: BatchingMode;
+  /**
+   * Suppress the UI notification emitted when a batch is skipped because the
+   * summary would have been larger than the raw tool-result text. The frontier
+   * still advances; only the notification is silenced. Useful for sessions
+   * dominated by small tool calls where this fires on nearly every turn.
+   */
+  quietOversizedSkips: boolean;
 }
 
 export const DEFAULT_CONFIG: ContextPruneConfig = {
@@ -184,6 +191,7 @@ export const DEFAULT_CONFIG: ContextPruneConfig = {
   pruneOn: "agent-message",
   remindUnprunedCount: true,
   batchingMode: "turn",
+  quietOversizedSkips: false,
 };
 
 // ── Captured batch ─────────────────────────────────────────────────────────


### PR DESCRIPTION
Fixes #16.

The pruner correctly skipping a batch whose summary would be larger than the raw tool outputs is the expected outcome on small-turn sessions, not an error condition. Surfacing it as a UI **warning** trains users to dismiss all pruner warnings.

Single-line change: `safeNotify(..., "warning")` → `safeNotify(..., "info")` at the oversized-batch skip notification site. Added a short comment explaining why it is info, not warning.

If you'd prefer to keep it as warning and instead gate it behind a new `quietOversizedSkips` setting (the option (2) from the issue), happy to revise — but this is the smallest patch and, I think, the correct framing.