### PR TITLE
Honor PI_CODING_AGENT_DIR when resolving settings path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ pi-context-prune/
 ├── package.json                   # Pi package manifest; declares extension at ./index.ts
 └── src/
     ├── types.ts                   # Shared types, constants, and interfaces (including PruneOn modes)
-    ├── config.ts                  # Load/save ~/.pi/agent/context-prune/settings.json
+    ├── config.ts                  # Load/save <agent-dir>/context-prune/settings.json (honors PI_CODING_AGENT_DIR)
     ├── batch-capture.ts           # Capture turn results from events or session branch
     ├── summarizer.ts              # LLM call that summarizes a CapturedBatch to markdown
     ├── indexer.ts                 # Runtime Map<toolCallId, ToolCallRecord> + session persistence
@@ -49,7 +49,7 @@ Wires all modules together and registers Pi event handlers:
 - **`flushPending(ctx, options?)`** — summarizes + indexes all unsummarized batches in parallel by default, or sequentially (one call per batch) when `options.onProgress` is provided. Accepts `FlushOptions`: `{ delivery?, onProgress?, onBatchTextProgress?, previewedBatches? }`. When `previewedBatches` is set the internal capture step is skipped (avoids double-capture from `/pruner now`). While summarization is running, `onBatchTextProgress` receives the streamed summary character count for the active batch so callers can surface live progress in richer UIs (the `/pruner now` overlay and `context_prune` tool updates), while the footer itself stays at the simpler `prune: summarizing…` state. Returns a typed `FlushResult`.
 
 - **`syncToolActivation()`** — activates or deactivates the `context_prune` tool in the Pi active-tools list based on whether `enabled && pruneOn === "agentic-auto"`. Uses `pi.getActiveTools()` / `pi.setActiveTools()` (ExtensionAPI, not ExtensionContext).
-- **`session_start`** — loads config from `~/.pi/agent/context-prune/settings.json`, rebuilds the in-memory index and stats accumulator, clears `pendingBatches`, updates the footer status widget, calls `syncToolActivation()`, and notifies the user of the loaded state.
+- **`session_start`** — loads config from `<agent-dir>/context-prune/settings.json` (where `<agent-dir>` honors `PI_CODING_AGENT_DIR`), rebuilds the in-memory index and stats accumulator, clears `pendingBatches`, updates the footer status widget, calls `syncToolActivation()`, and notifies the user of the loaded state.
 - **`session_tree`** — rebuilds the index and stats accumulator after branch navigation (pending batches and stats belong to the current branch).
 - **`turn_end`** — captures the batch (filtering out any `context_prune` tool call to avoid re-queuing agentic-auto housekeeping), pushes to `pendingBatches`. Behavior depends on `pruneOn` mode:
   - `every-turn`: flushes immediately with `delivery: "session"`.
@@ -78,7 +78,7 @@ Single source of truth for all interfaces and constants:
 - **`PRUNE_ON_MODES`** — `{ value, label }` array for interactive selectors.
 - **`BATCHING_MODES`** — `{ value, label }` array for interactive selectors.
 - **`SUMMARIZER_THINKING_LEVELS`** — `{ value, label }` array for interactive selectors.
-- **`ContextPruneConfig`** — `{ enabled, showPruneStatusLine, summarizerModel, summarizerThinking, pruneOn, remindUnprunedCount, batchingMode }` stored in `~/.pi/agent/context-prune/settings.json`.
+- **`ContextPruneConfig`** — `{ enabled, showPruneStatusLine, summarizerModel, summarizerThinking, pruneOn, remindUnprunedCount, batchingMode }` stored in `<agent-dir>/context-prune/settings.json` (per-agent-dir; honors `PI_CODING_AGENT_DIR`).
 - **`SummarizerStats`** — cumulative token/cost stats: `{ totalInputTokens, totalOutputTokens, totalCost, callCount }`. Persisted via `pi.appendEntry(CUSTOM_TYPE_STATS, ...)`.
 - **`ProgressCallback`** — `(index, total, batch, stage: "start" | "done" | "skipped") => void` — progress callback fired by `flushPending` when processing batches sequentially. Only used when the caller passes `onProgress` in `FlushOptions` (i.e. `/pruner now`).
 - **`BatchTextProgressCallback`** — `(index, total, batch, receivedChars) => void` — live callback fired while the summarizer streams text for the active batch in `/pruner now`.
@@ -90,7 +90,7 @@ Single source of truth for all interfaces and constants:
 - Constants: `CUSTOM_TYPE_SUMMARY`, `CUSTOM_TYPE_INDEX`, `CUSTOM_TYPE_STATS`, `STATUS_WIDGET_ID`, `DEFAULT_CONFIG`, `CONTEXT_PRUNE_TOOL_NAME`, `AGENTIC_AUTO_SYSTEM_PROMPT`.
 
 ### `src/config.ts` — Config persistence
-- **`SETTINGS_PATH`** — constant resolving to `~/.pi/agent/context-prune/settings.json` (global, project-independent).
+- **`SETTINGS_PATH`** — constant resolving to `<agent-dir>/context-prune/settings.json`. `<agent-dir>` comes from pi's `getAgentDir()` (`@mariozechner/pi-coding-agent`): `$PI_CODING_AGENT_DIR` if set (tilde-expanded), else `~/.pi/agent`. Project-independent but scoped per agent-dir so each pi preset has its own settings (including its own `summarizerModel`).
 - **`loadConfig()`** — reads `SETTINGS_PATH`, parses JSON, merges with `DEFAULT_CONFIG`. Returns defaults on any read/parse error.
 - **`saveConfig(config)`** — creates the directory if needed (`mkdir recursive`) then writes the full config as the file root (no key wrapping).
 
@@ -209,7 +209,7 @@ Accumulates cumulative token/cost stats for summarizer LLM calls and persists th
 | `pi.appendEntry` for persistence | Session custom entries survive restarts and branch navigation; index is rebuilt on `session_start` / `session_tree` |
 | `summarizerModel: "default"` | Reuses the active model's credentials via `ctx.modelRegistry.getApiKeyAndHeaders()` — no hidden side-channel or extra config needed |
 | `summarizerThinking` setting | Lets users trade summarizer cost/latency for quality; `"default"` preserves old behavior (no explicit reasoning option sent) |
-| Config in `~/.pi/agent/context-prune/settings.json` | Extension owns its own file — no risk of clobbering other Pi settings, and config persists across all projects |
+| Config in `<agent-dir>/context-prune/settings.json` (agent-dir honors `PI_CODING_AGENT_DIR`) | Extension owns its own file — no risk of clobbering other Pi settings; config persists across all projects within an agent-dir, and each pi preset directory gets its own config (different summarizer model per preset) |
 | Five `pruneOn` trigger modes | `every-turn` (immediate), `on-context-tag` (aligned with save-points), `on-demand` (manual), `agent-message` (batch until final text response), `agentic-auto` (LLM decides via `context_prune` tool) — lets users trade immediacy for batch efficiency |
 | `pendingBatches` queue + `flushPending` | Decouples capture (always at `turn_end`) from summarization (mode-dependent). `flushPending` drains all pending batches into a **single** `summarizeBatches` LLM call, reducing round-trips from N to 1. |
 | `message_end` instead of `turn_end` for `agent-message` flush | `message_end` fires reliably at the final text-only response and before session teardown, giving time to capture the sessionManager before awaiting the summarizer LLM call. `turn_end` in print mode fires too late. |

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ The extension registers the `/pruner` command:
 4. **Summarizer model** — press Enter to open a searchable submenu listing `"default"` plus all available models
 5. **Summarizer thinking** — cycle through the thinking/reasoning level used for summarizer calls
 
-All changes are saved immediately to `~/.pi/agent/context-prune/settings.json` and reflected in the footer status widget when it is enabled.
+All changes are saved immediately to `<agent-dir>/context-prune/settings.json` and reflected in the footer status widget when it is enabled. `<agent-dir>` is whatever pi resolves for the current session — `$PI_CODING_AGENT_DIR` if set (with tilde expansion), otherwise `~/.pi/agent`. Each preset directory therefore gets its own settings file, including its own summarizer model.
 
 ## Tools
 
@@ -187,7 +187,7 @@ The tool is guided by a system prompt that instructs the model to use it after c
 
 ## Configuration
 
-Config is stored in `~/.pi/agent/context-prune/settings.json` (global, project-independent):
+Config is stored in `<agent-dir>/context-prune/settings.json` (project-independent, but scoped to the active pi agent directory — `$PI_CODING_AGENT_DIR` or `~/.pi/agent`):
 
 ```json
 {
@@ -244,7 +244,7 @@ Set it with:
 /pruner settings
 ```
 
-Or directly in `~/.pi/agent/context-prune/settings.json`:
+Or directly in `<agent-dir>/context-prune/settings.json`:
 
 ```json
 {
@@ -259,7 +259,7 @@ Or directly in `~/.pi/agent/context-prune/settings.json`:
 index.ts                    — entry point, wires events + modules
 src/
   types.ts                  — shared types, constants, PruneOn modes
-  config.ts                 — load/save ~/.pi/agent/context-prune/settings.json
+  config.ts                 — load/save <agent-dir>/context-prune/settings.json (honors PI_CODING_AGENT_DIR)
   batch-capture.ts          — serialize turn_end event → CapturedBatch
   summarizer.ts             — resolve model, call LLM, build summary text
   indexer.ts                — Map<toolCallId, ToolCallRecord> + session persistence
@@ -276,7 +276,7 @@ src/
 
 ```
 session_start
-  └─► loadConfig()              read ~/.pi/agent/context-prune/settings.json
+  └─► loadConfig()              read <agent-dir>/context-prune/settings.json
   └─► indexer.reconstruct()     rebuild Map from session branch entries
   └─► statsAccum.reconstruct()  rebuild stats from session branch entries
   └─► frontier.reconstruct()    rebuild last prune-attempt boundary from session entries
@@ -322,7 +322,7 @@ before_agent_start (agentic-auto mode)
 
 ### Session persistence
 
-- **Config** lives in `~/.pi/agent/context-prune/settings.json` — the extension's own file, independent of Pi's project settings
+- **Config** lives in `<agent-dir>/context-prune/settings.json` — the extension's own file, independent of Pi's project settings. `<agent-dir>` resolves through pi's `getAgentDir()` so it honors `PI_CODING_AGENT_DIR` (default `~/.pi/agent`)
 - **Index** is persisted via `pi.appendEntry("context-prune-index", { toolCalls })` — one entry per summarized batch, NOT in LLM context
 - **Prune frontier** is persisted via `pi.appendEntry("context-prune-frontier", ...)` — it records the last attempted prune boundary even when an oversized summary is rejected
 - **Summaries** are injected as `custom_message` entries with `customType: "context-prune-summary"` — these ARE in LLM context (replacing the raw outputs only when pruning is accepted). Their visible text uses short refs, while the `details.toolCallRefs` metadata keeps the full `toolCallId` mapping for later recovery.

--- a/index.ts
+++ b/index.ts
@@ -2,7 +2,7 @@
  * context-prune — Pi extension entry point
  *
  * Wires together all modules:
- *   config       — load/save ~/.pi/agent/context-prune/settings.json
+ *   config       — load/save <agent-dir>/context-prune/settings.json (honors PI_CODING_AGENT_DIR)
  *   batch-capture — serialize turn_end event into CapturedBatch
  *   summarizer   — call LLM to summarize a CapturedBatch
  *   indexer      — maintain Map<toolCallId, ToolCallRecord> + session persistence
@@ -387,7 +387,7 @@ export default function (pi: ExtensionAPI) {
 
   // ── session_start: restore config + index + stats ────────────────────────────────
   pi.on("session_start", async (_event, ctx) => {
-    // Load config from ~/.pi/agent/context-prune/settings.json
+    // Load config from <agent-dir>/context-prune/settings.json (honors PI_CODING_AGENT_DIR)
     currentConfig.value = await loadConfig();
 
     // Rebuild in-memory index from persisted session entries

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -219,7 +219,7 @@ Related:
   - pi-context extension (provides context_tag): https://github.com/ttttmr/pi-context
   - Anthropic prompt caching docs: https://docs.claude.com/en/docs/build-with-claude/prompt-caching
 
-Settings are saved to ~/.pi/agent/context-prune/settings.json`;
+Settings are saved to <agent-dir>/context-prune/settings.json (where <agent-dir> is $PI_CODING_AGENT_DIR or ~/.pi/agent).`;
 
 // ── Pruner progress widget ────────────────────────────────────────────────────
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,11 +1,16 @@
 import { readFile, writeFile, mkdir } from "node:fs/promises";
 import { join, dirname } from "node:path";
-import { homedir } from "node:os";
+import { getAgentDir } from "@mariozechner/pi-coding-agent";
 import type { ContextPruneConfig, PruneOn, SummarizerThinking } from "./types.js";
 import { DEFAULT_CONFIG, PRUNE_ON_MODES, SUMMARIZER_THINKING_LEVELS } from "./types.js";
 
-/** Path to the extension's own settings file, independent of any project. */
-export const SETTINGS_PATH = join(homedir(), ".pi", "agent", "context-prune", "settings.json");
+/**
+ * Path to the extension's own settings file, independent of any project.
+ * Resolved against pi's agent directory so it honors `PI_CODING_AGENT_DIR`
+ * (defaults to `~/.pi/agent`). Each pi preset directory therefore gets its
+ * own context-prune config — including its own summarizer model.
+ */
+export const SETTINGS_PATH = join(getAgentDir(), "context-prune", "settings.json");
 
 function isPruneOn(value: unknown): value is PruneOn {
   return typeof value === "string" && PRUNE_ON_MODES.some((mode) => mode.value === value);
@@ -15,7 +20,7 @@ function isSummarizerThinking(value: unknown): value is SummarizerThinking {
   return typeof value === "string" && SUMMARIZER_THINKING_LEVELS.some((level) => level.value === value);
 }
 
-/** Reads ~/.pi/agent/context-prune/settings.json and returns the config (or defaults). */
+/** Reads `<agent-dir>/context-prune/settings.json` and returns the config (or defaults). */
 export async function loadConfig(): Promise<ContextPruneConfig> {
   try {
     const raw = await readFile(SETTINGS_PATH, "utf-8");
@@ -42,7 +47,7 @@ export async function loadConfig(): Promise<ContextPruneConfig> {
   }
 }
 
-/** Writes the full config to ~/.pi/agent/context-prune/settings.json. */
+/** Writes the full config to `<agent-dir>/context-prune/settings.json`. */
 export async function saveConfig(config: ContextPruneConfig): Promise<void> {
   await mkdir(dirname(SETTINGS_PATH), { recursive: true });
   await writeFile(SETTINGS_PATH, JSON.stringify(config, null, 2));

--- a/src/types.ts
+++ b/src/types.ts
@@ -143,7 +143,7 @@ export const PRUNE_ON_MODES: { value: PruneOn; label: string }[] = [
   { value: "agentic-auto", label: "Agentic auto" },
 ];
 
-/** Extension config stored in ~/.pi/agent/context-prune/settings.json */
+/** Extension config stored in `<agent-dir>/context-prune/settings.json` (agent-dir honors `PI_CODING_AGENT_DIR`). */
 export interface ContextPruneConfig {
   /** Whether to prune raw tool outputs from future LLM context */
   enabled: boolean;


### PR DESCRIPTION
Fixes #18.

## What

Use `getAgentDir()` from `@mariozechner/pi-coding-agent` (already a peer dep) to resolve the settings path, instead of hardcoding `join(homedir(), ".pi", "agent", ...)`.

```diff
-import { homedir } from "node:os";
-export const SETTINGS_PATH = join(homedir(), ".pi", "agent", "context-prune", "settings.json");
+import { getAgentDir } from "@mariozechner/pi-coding-agent";
+export const SETTINGS_PATH = join(getAgentDir(), "context-prune", "settings.json");
```

`getAgentDir()` is pi's own resolver — it honors `PI_CODING_AGENT_DIR` (with tilde expansion) and falls back to `~/.pi/agent`. Verified locally:

```
PI_CODING_AGENT_DIR=/Users/jacek/.pi/agent.anthropic
node -e "console.log(require('@mariozechner/pi-coding-agent').getAgentDir())"
# → /Users/jacek/.pi/agent.anthropic
```

## Why

Pi supports multiple preset agent directories via `PI_CODING_AGENT_DIR` (e.g. `~/.pi/agent.anthropic`, `~/.pi/agent.bedrock`, each with their own `models.json` / `auth.json` / `settings.json`). Before this change, `pi-context-prune` always wrote to `~/.pi/agent/context-prune/settings.json` regardless of the active preset, with two effects:

- Config landed in an orphan directory (silent fallback to defaults next session).
- No way to use a different `summarizerModel` per preset — one shared file across all of them, with model IDs that may not even exist in every provider.

## Changes

- `src/config.ts`: swap `homedir()`-based path for `getAgentDir()`.
- Doc strings in `src/config.ts`, `src/types.ts`, `src/commands.ts`, `index.ts`, `README.md`, `AGENTS.md`: describe the path as `<agent-dir>/context-prune/settings.json` and note that `<agent-dir>` honors `PI_CODING_AGENT_DIR`. No structural / behavioral changes beyond the one resolver swap.

## Compatibility

- Default case (`PI_CODING_AGENT_DIR` unset) — path is still `~/.pi/agent/context-prune/settings.json`. Existing installs see no change.
- Users on a custom `PI_CODING_AGENT_DIR` who already have a file at the legacy `~/.pi/agent/context-prune/settings.json` will see defaults on first run under the new path and can copy the file over (or re-set via `/pruner`). I didn't add a migration shim — happy to add one if you'd prefer.
