### PR TITLE
feat: add notifySkipped config to silence skipped-pruning warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,9 +208,11 @@ Config is stored in `~/.pi/agent/context-prune/settings.json` (global, project-i
 | `summarizerThinking` | `"default"`, `"off"`, `"minimal"`, `"low"`, `"medium"`, `"high"`, `"xhigh"` | `"default"` |
 | `pruneOn` | `"every-turn"`, `"on-context-tag"`, `"on-demand"`, `"agent-message"`, `"agentic-auto"` | `"agent-message"` |
 | `remindUnprunedCount` | `true` / `false` | `true` |
+| `notifySkipped` | `true` / `false` | `true` |
 
 - `showPruneStatusLine: true` keeps the prune footer widget and the automatic queued-turn notice visible. Turn it off if you want pruning to stay active without the extra status noise.
 - `remindUnprunedCount: true` appends a small ephemeral `<pruner-note>` to the last tool result before each LLM call to remind the model of the number of unpruned tool calls in context. This only has an effect when `pruneOn` is set to `"agentic-auto"`.
+- `notifySkipped: false` silences the "skipped pruning" warning shown when a summary would be larger than the raw tool output it replaces (pruning is skipped in that case; only the notification is suppressed).
 
 - `summarizerModel: "default"` means the current active Pi model. An explicit value like `"anthropic/claude-haiku-3-5"` uses that model for summarization (must be registered in Pi and have an API key).
 - `summarizerThinking: "default"` preserves old behavior: no explicit thinking/reasoning option is added to summarizer calls.

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -750,10 +750,12 @@ export function registerCommands(
           }
 
           if (result.reason === "skipped-oversized") {
-            ctx.ui.notify(
-              `pruner: skipped pruning ${result.toolCallCount} tool call${result.toolCallCount === 1 ? "" : "s"} — summary was ${result.summaryCharCount} chars vs ${result.rawCharCount} raw chars; frontier advanced past this range`,
-              "warning"
-            );
+            if (currentConfig.value.notifySkipped) {
+              ctx.ui.notify(
+                `pruner: skipped pruning ${result.toolCallCount} tool call${result.toolCallCount === 1 ? "" : "s"} — summary was ${result.summaryCharCount} chars vs ${result.rawCharCount} raw chars; frontier advanced past this range`,
+                "warning"
+              );
+            }
             break;
           }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -36,6 +36,8 @@ export async function loadConfig(): Promise<ContextPruneConfig> {
         typeof merged.remindUnprunedCount === "boolean"
           ? merged.remindUnprunedCount
           : DEFAULT_CONFIG.remindUnprunedCount,
+      notifySkipped:
+        typeof merged.notifySkipped === "boolean" ? merged.notifySkipped : DEFAULT_CONFIG.notifySkipped,
     };
   } catch {
     return { ...DEFAULT_CONFIG };

--- a/src/types.ts
+++ b/src/types.ts
@@ -178,6 +178,11 @@ export interface ContextPruneConfig {
    */
   remindUnprunedCount: boolean;
   /**
+   * Whether to show a warning notification when pruning is skipped because the
+   * generated summary would be larger than the raw tool output it replaces.
+   */
+  notifySkipped: boolean;
+  /**
    * Granularity of each pruning batch.
    * - "turn"          : one summary per assistant turn (default)
    * - "agent-message" : one summary per user → final-agent-message span
@@ -193,6 +198,7 @@ export const DEFAULT_CONFIG: ContextPruneConfig = {
   summarizerThinking: "default",
   pruneOn: "agent-message",
   remindUnprunedCount: true,
+  notifySkipped: true,
   batchingMode: "turn",
 };
 


### PR DESCRIPTION
## Summary

When `/pruner now` skips a batch because the generated summary would be **larger** than the raw tool output it replaces (the "skipped-oversized" guard), it currently emits a `warning` notification every time:

> `pruner: skipped pruning 1 tool call — summary was 814 chars vs 300 raw chars; frontier advanced past this range`

This is informational (pruning is skipped deliberately; the frontier still advances), but it fires even for single tiny tool outputs, which makes it noise for users who prune often.

## Change

Add a `notifySkipped` config key (default `true` — current behavior unchanged) that gates that notification:

```jsonc
// ~/.pi/agent/context-prune/settings.json
{ "notifySkipped": false }
```

- `src/types.ts` — `notifySkipped` on `ContextPruneConfig` + `DEFAULT_CONFIG`
- `src/config.ts` — boolean validation on load (mirrors `remindUnprunedCount`)
- `src/commands.ts` — only notify when `currentConfig.value.notifySkipped`
- `README.md` — document the key

## Testing

- Verified the module loads cleanly through jiti (pi's loader) after the change.
- Default path (`notifySkipped` unset) preserves the existing notification; setting `false` suppresses it. The skip itself and frontier advancement are untouched.