### PR TITLE
feat: skip summarization for small tool-output batches

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,8 @@ Config is stored in `~/.pi/agent/context-prune/settings.json` (global, project-i
   "summarizerThinking": "default",
   "pruneOn": "agent-message",
   "remindUnprunedCount": true,
+  "notifySkipped": true,
+  "minRawChars": 1500,
   "batchingMode": "turn"
 }
 ```
@@ -218,12 +220,14 @@ Config is stored in `~/.pi/agent/context-prune/settings.json` (global, project-i
 | `pruneOn` | `"every-turn"`, `"on-context-tag"`, `"on-demand"`, `"agent-message"`, `"agentic-auto"` | `"agent-message"` |
 | `remindUnprunedCount` | `true` / `false` | `true` |
 | `notifySkipped` | `true` / `false` | `true` |
+| `minRawChars` | non-negative integer | `1500` |
 | `batchingMode` | `"turn"` / `"agent-message"` | `"turn"` |
 
 - `showPruneStatusLine: true` keeps the prune footer widget and the automatic queued-turn notice visible. Turn it off if you want pruning to stay active without that extra status noise.
 - `showStartupNotice: true` shows the passive `pruner loaded — pruning ON/OFF | model: ...` info notice when a session starts. Turn it off if you want startup to stay quiet; manual command output and real errors still appear.
 - `remindUnprunedCount: true` appends a small ephemeral `<pruner-note>` to the last tool result before each LLM call to remind the model of the number of unpruned tool calls in context. This only has an effect when `pruneOn` is set to `"agentic-auto"`.
 - `notifySkipped: false` silences the "skipped pruning" warning shown when a summary would be larger than the raw tool output it replaces (pruning is skipped in that case; only the notification is suppressed).
+- `minRawChars` skips the summarizer call when a grouped batch contains fewer raw tool-result characters than the threshold. The frontier still advances so the same small batch is not queued again. Set it to `0` to disable this pre-check.
 - `batchingMode: "turn"` keeps one summary per assistant tool-using turn. Set it to `"agent-message"` to merge all assistant turns between two user messages into one summary.
 
 - `summarizerModel: "default"` means the current active Pi model. An explicit value like `"anthropic/claude-haiku-3-5"` uses that model for summarization (must be registered in Pi and have an API key).

--- a/index.ts
+++ b/index.ts
@@ -58,7 +58,7 @@ export default function (pi: ExtensionAPI) {
   let isFlushing = false;
 
   type FlushResult =
-    | { ok: true; reason: "flushed" | "skipped-oversized"; batchCount: number; toolCallCount: number; rawCharCount: number; summaryCharCount: number }
+    | { ok: true; reason: "flushed" | "skipped-small" | "skipped-oversized"; batchCount: number; toolCallCount: number; rawCharCount: number; summaryCharCount: number }
     | { ok: false; reason: "empty" | "already-flushing" | "summarizer-failed" | "stale-context" | "failed" | "aborted"; error?: string };
 
   type SessionAppender = {
@@ -202,10 +202,21 @@ export default function (pi: ExtensionAPI) {
       // Summarize batches. When onProgress is provided (i.e. /pruner now with the
       // multi-row overlay) we process sequentially so each row can be checked off
       // as its LLM call completes. Otherwise all batches run in parallel.
-      let results: (import("./src/types.js").SummarizeResult | null)[];
+      const rawCharCounts = batches.map((batch) =>
+        batch.toolCalls.reduce((sum, toolCall) => sum + toolCall.resultText.length, 0)
+      );
+      const smallBatches = new Set(
+        batches.filter((_batch, index) => rawCharCounts[index] < currentConfig.value.minRawChars)
+      );
+      let results: (import("./src/types.js").SummarizeResult | null | undefined)[];
       if (options.onProgress) {
         results = [];
         for (let i = 0; i < batches.length; i++) {
+          if (smallBatches.has(batches[i])) {
+            results.push(undefined);
+            options.onProgress(i, batches.length, batches[i], "skipped");
+            continue;
+          }
           options.onProgress(i, batches.length, batches[i], "start");
           const r = await summarizeBatch(batches[i], currentConfig.value, ctx, {
             signal: options.signal,
@@ -218,10 +229,16 @@ export default function (pi: ExtensionAPI) {
         }
       } else {
         // Parallel — one LLM call per batch, all in flight simultaneously.
-        results = await summarizeBatches(batches, currentConfig.value, ctx, {
-          onBatchTextProgress: reportBatchTextProgress,
+        const summarizableBatches = batches.filter((batch) => !smallBatches.has(batch));
+        const summarized = await summarizeBatches(summarizableBatches, currentConfig.value, ctx, {
+          onBatchTextProgress: (_index, _total, batch, receivedChars) =>
+            reportBatchTextProgress(batches.indexOf(batch), batches.length, batch, receivedChars),
           signal: options.signal,
         });
+        let summarizedIndex = 0;
+        results = batches.map((batch) =>
+          smallBatches.has(batch) ? undefined : summarized[summarizedIndex++]
+        );
       }
 
       // Process results in order; stop at first null (individual call failure).
@@ -232,17 +249,25 @@ export default function (pi: ExtensionAPI) {
       let totalSummaryCharCount = 0;
       let totalToolCallCount = 0;
       const oversizedBatches: CapturedBatch[] = [];
+      let processedSmallBatchCount = 0;
       let firstFailureIndex = -1;
 
       for (let i = 0; i < batches.length; i++) {
         const result = results[i];
-        if (!result) {
+        if (result === null) {
           firstFailureIndex = i;
           break;
         }
 
         const batch = batches[i];
-        const batchRawCharCount = batch.toolCalls.reduce((s, tc) => s + tc.resultText.length, 0);
+        const batchRawCharCount = rawCharCounts[i];
+        if (result === undefined) {
+          processedSmallBatchCount++;
+          totalRawCharCount += batchRawCharCount;
+          totalToolCallCount += batch.toolCalls.length;
+          processedBatches.push(batch);
+          continue;
+        }
         const summaryRefs = indexer.allocateSummaryRefs(batch);
         const summaryText = wrapSummaryForContext(result.summaryText + formatSummaryToolCallRefs(summaryRefs));
         const shouldSkipOversized = summaryText.length > batchRawCharCount;
@@ -302,6 +327,7 @@ export default function (pi: ExtensionAPI) {
       const lastBatch = processedBatches[processedBatches.length - 1];
       const lastTC = lastBatch.toolCalls[lastBatch.toolCalls.length - 1];
       const allOversized = oversizedBatches.length === processedBatches.length;
+      const allSmall = processedSmallBatchCount === processedBatches.length;
       const frontierSnapshot: PruneFrontier = {
         lastAttemptedToolCallId: lastTC.toolCallId,
         lastAttemptedToolName: lastTC.toolName,
@@ -311,7 +337,7 @@ export default function (pi: ExtensionAPI) {
         attemptedToolCallCount: totalToolCallCount,
         rawCharCount: totalRawCharCount,
         summaryCharCount: totalSummaryCharCount,
-        outcome: allOversized ? "skipped-oversized" : "summarized",
+        outcome: allSmall ? "skipped-small" : allOversized ? "skipped-oversized" : "summarized",
       };
 
       try {
@@ -347,7 +373,7 @@ export default function (pi: ExtensionAPI) {
 
       return {
         ok: true,
-        reason: allOversized ? "skipped-oversized" : "flushed",
+        reason: allSmall ? "skipped-small" : allOversized ? "skipped-oversized" : "flushed",
         batchCount: processedBatches.length,
         toolCallCount: totalToolCallCount,
         rawCharCount: totalRawCharCount,

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "LICENSE"
   ],
   "scripts": {
-    "build": "rm -rf dist && esbuild index.ts --bundle --platform=node --target=node20 --format=esm --outfile=dist/index.js --sourcemap --external:@earendil-works/pi-ai --external:@earendil-works/pi-coding-agent --external:@earendil-works/pi-tui",
+    "test": "npm run check",
+    "build": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\" && esbuild index.ts --bundle --platform=node --target=node20 --format=esm --outfile=dist/index.js --sourcemap --external:@earendil-works/pi-ai --external:@earendil-works/pi-coding-agent --external:@earendil-works/pi-tui",
     "check": "npm run build && npm run check:package",
     "check:package": "node scripts/check-package.mjs",
     "prepack": "npm run build && npm run check:package"

--- a/scripts/check-package.mjs
+++ b/scripts/check-package.mjs
@@ -4,14 +4,16 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
 const packageRoot = fileURLToPath(new URL("../", import.meta.url));
+const npmCli = process.env.npm_execpath;
+assert(npmCli, "npm_execpath is required to run the package check");
 const packageJson = JSON.parse(
   readFileSync(new URL("../package.json", import.meta.url), "utf8"),
 );
 
 // Guard the published tarball contract so releases cannot regress to raw TypeScript.
 const packOutput = execFileSync(
-  "npm",
-  ["pack", "--dry-run", "--json", "--ignore-scripts"],
+  process.execPath,
+  [npmCli, "pack", "--dry-run", "--json", "--ignore-scripts"],
   { cwd: packageRoot, encoding: "utf8" },
 );
 const packResults = JSON.parse(packOutput);

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -354,7 +354,7 @@ export function registerCommands(
   pi: ExtensionAPI,
   currentConfig: { value: ContextPruneConfig },
   flushPending: (ctx: ExtensionCommandContext, options?: FlushOptions) => Promise<
-    | { ok: true; reason: "flushed" | "skipped-oversized"; batchCount: number; toolCallCount: number; rawCharCount: number; summaryCharCount: number }
+    | { ok: true; reason: "flushed" | "skipped-small" | "skipped-oversized"; batchCount: number; toolCallCount: number; rawCharCount: number; summaryCharCount: number }
     | { ok: false; reason: string; error?: string }
   >,
   capturePendingBatches: (ctx: ExtensionCommandContext) => CapturedBatch[],
@@ -775,6 +775,16 @@ export function registerCommands(
               ctx.ui.notify(
                 `pruner: skipped pruning ${result.toolCallCount} tool call${result.toolCallCount === 1 ? "" : "s"} — summary was ${result.summaryCharCount} chars vs ${result.rawCharCount} raw chars; frontier advanced past this range`,
                 "warning"
+              );
+            }
+            break;
+          }
+
+          if (result.reason === "skipped-small") {
+            if (currentConfig.value.notifySkipped) {
+              ctx.ui.notify(
+                `pruner: skipped ${result.toolCallCount} tool call${result.toolCallCount === 1 ? "" : "s"} — ${result.rawCharCount} raw chars is below minRawChars (${currentConfig.value.minRawChars}); frontier advanced past this range`,
+                "info"
               );
             }
             break;

--- a/src/config.ts
+++ b/src/config.ts
@@ -42,6 +42,10 @@ export async function loadConfig(): Promise<ContextPruneConfig> {
           : DEFAULT_CONFIG.remindUnprunedCount,
       notifySkipped:
         typeof merged.notifySkipped === "boolean" ? merged.notifySkipped : DEFAULT_CONFIG.notifySkipped,
+      minRawChars:
+        typeof merged.minRawChars === "number" && Number.isFinite(merged.minRawChars) && merged.minRawChars >= 0
+          ? Math.floor(merged.minRawChars)
+          : DEFAULT_CONFIG.minRawChars,
     };
   } catch {
     return { ...DEFAULT_CONFIG };

--- a/src/context-prune-tool.ts
+++ b/src/context-prune-tool.ts
@@ -22,6 +22,7 @@ import { pruneProgressText } from "./progress-text.js";
  */
 type FlushResult =
   | { ok: true; reason: "flushed"; batchCount: number; toolCallCount: number; rawCharCount: number; summaryCharCount: number }
+  | { ok: true; reason: "skipped-small"; batchCount: number; toolCallCount: number; rawCharCount: number; summaryCharCount: number }
   | { ok: true; reason: "skipped-oversized"; batchCount: number; toolCallCount: number; rawCharCount: number; summaryCharCount: number }
   | { ok: false; reason: string; error?: string };
 
@@ -97,6 +98,13 @@ export function registerContextPruneTool(
                 text: `Context prune skipped ${result.toolCallCount} tool call${result.toolCallCount === 1 ? "" : "s"}: the summary was ${result.summaryCharCount} chars while the raw tool results were ${result.rawCharCount} chars. The original tool results were kept, and the prune frontier advanced so the next prune starts after this range.`,
               },
             ],
+            details: result,
+          };
+        }
+
+        if (result.reason === "skipped-small") {
+          return {
+            content: [{ type: "text", text: `Skipped ${result.toolCallCount} tool call${result.toolCallCount === 1 ? "" : "s"}: raw output was below minRawChars; frontier advanced.` }],
             details: result,
           };
         }

--- a/src/types.ts
+++ b/src/types.ts
@@ -184,6 +184,8 @@ export interface ContextPruneConfig {
    * generated summary would be larger than the raw tool output it replaces.
    */
   notifySkipped: boolean;
+  /** Skip summarizer calls for batches whose raw tool output is below this size. */
+  minRawChars: number;
   /**
    * Granularity of each pruning batch.
    * - "turn"          : one summary per assistant turn (default)
@@ -202,6 +204,7 @@ export const DEFAULT_CONFIG: ContextPruneConfig = {
   pruneOn: "agent-message",
   remindUnprunedCount: true,
   notifySkipped: true,
+  minRawChars: 1500,
   batchingMode: "turn",
 };
 
@@ -303,7 +306,7 @@ export interface SummarizerStats {
 }
 
 /** Outcome of the most recent completed prune attempt. */
-export type PruneFrontierOutcome = "summarized" | "skipped-oversized";
+export type PruneFrontierOutcome = "summarized" | "skipped-small" | "skipped-oversized";
 
 /**
  * Snapshot of the last successfully completed prune attempt boundary.
@@ -329,7 +332,7 @@ export interface PruneFrontier {
   rawCharCount: number;
   /** Character count of the rendered summary text that was produced */
   summaryCharCount: number;
-  /** Whether the attempt actually pruned or was skipped for being oversized */
+  /** Whether the attempt actually pruned or was skipped before/after summarization */
   outcome: PruneFrontierOutcome;
 }
 


### PR DESCRIPTION
## Summary

- add a configurable `minRawChars` threshold, defaulting to `1500`
- skip small tool-output batches before invoking the summarizer
- advance and persist the prune frontier with a `skipped-small` outcome so skipped batches are not queued repeatedly
- preserve the existing post-summarization `skipped-oversized` behavior
- support mixed queues containing both skipped-small and summarizable batches
- document that setting `minRawChars` to `0` disables the pre-check
- make the existing build and package verification scripts work on Windows

## Motivation

Small tool outputs can cost more to summarize than they save. Previously, every eligible batch invoked the summarizer, even when the raw output was only a few hundred characters.

Simply omitting these batches is insufficient because session rescans would discover them again. This change treats a threshold skip as a completed prune attempt and advances the frontier past the final skipped tool call. The original tool results remain in context because skipped-small batches are not added to the prune index.

## Behavior

For each grouped batch:

- when `rawCharCount < minRawChars`, no summarizer call is made and the frontier advances with `outcome: "skipped-small"`
- otherwise, summarization proceeds normally
- if the produced summary is larger than the raw output, the existing `skipped-oversized` path remains unchanged
- operational summarizer failures continue to restore unprocessed batches and do not advance past the failure

`minRawChars: 0` preserves the previous behavior by disabling the pre-summarization threshold.

## Verification

- `npm test`
- esbuild bundle completed successfully
- package dry-run verification passed
- `git diff --check` passed